### PR TITLE
Planesnrey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ CFILES		=	$(SRCDIR)/minirt.c \
 				$(SRCDIR)/scene/light.c \
 				$(SRCDIR)/scene/scene.c \
 				$(SRCDIR)/scene/sphere.c \
+				$(SRCDIR)/hierarchy/hierarchy.c \
+				$(SRCDIR)/hierarchy/hierarchy_utils.c \
 
 OBJS		=	$(CFILES:.c=.o)
 
@@ -30,6 +32,7 @@ IFILES		=	$(INCLDIR)/minirt.h \
 				$(INCLDIR)/sphere.h \
 				$(INCLDIR)/scene.h \
 				$(INCLDIR)/utils.h \
+				$(INCLDIR)/hierarchy.h \
 				$(INCLDIR)/vector.h
 
 LIBFT_DIR	=	./libft

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ CFILES		=	$(SRCDIR)/minirt.c \
 				$(SRCDIR)/scene/scene.c \
 				$(SRCDIR)/scene/sphere.c \
 				$(SRCDIR)/scene/plane.c \
+				$(SRCDIR)/scene/cylinder.c \
 				$(SRCDIR)/hierarchy/hierarchy.c \
 				$(SRCDIR)/hierarchy/hierarchy_utils.c \
 
@@ -31,6 +32,8 @@ IFILES		=	$(INCLDIR)/minirt.h \
 				$(INCLDIR)/light.h \
 				$(INCLDIR)/material.h \
 				$(INCLDIR)/sphere.h \
+				$(INCLDIR)/cylinder.h \
+				$(INCLDIR)/plane.h \
 				$(INCLDIR)/scene.h \
 				$(INCLDIR)/utils.h \
 				$(INCLDIR)/hierarchy.h \

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ CFILES		=	$(SRCDIR)/minirt.c \
 				$(SRCDIR)/scene/cylinder.c \
 				$(SRCDIR)/hierarchy/hierarchy.c \
 				$(SRCDIR)/hierarchy/hierarchy_utils.c \
+				$(SRCDIR)/reflections/reflections.c \
 
 OBJS		=	$(CFILES:.c=.o)
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ CFILES		=	$(SRCDIR)/minirt.c \
 				$(SRCDIR)/scene/light.c \
 				$(SRCDIR)/scene/scene.c \
 				$(SRCDIR)/scene/sphere.c \
+				$(SRCDIR)/scene/plane.c \
 				$(SRCDIR)/hierarchy/hierarchy.c \
 				$(SRCDIR)/hierarchy/hierarchy_utils.c \
 

--- a/Makefile
+++ b/Makefile
@@ -97,9 +97,7 @@ test:			$(NAME)
 				@$(RM) $(RMFLAGS) $(LOG)
 				@printf "[!] - Launching test suite..."
 				@printf "\n==========================================================\n"
-				$(VALGRIND) $(VALFLAGS) ./$(NAME) 2>> $(LOG)
-				@read REPLY
-				@less -S $(LOG)
+				$(VALGRIND) $(VALFLAGS) ./$(NAME)
 
 # 42 Norm checks
 check:

--- a/include/cylinder.h
+++ b/include/cylinder.h
@@ -1,0 +1,13 @@
+#ifndef CYLINDER_H
+# define CYLINDER_H
+
+# include "point3.h"
+# include "minirt.h"
+# include "scene.h"
+# include "vector.h"
+# include <stdbool.h>
+
+bool	hit_cylinder(t_point3 *origin, t_vec3 *dir, t_shape *cyl, double *t);
+void	create_cylinder(t_point3 pos, t_vec3 dir, float radius, float height, t_material mat);
+
+#endif

--- a/include/cylinder.h
+++ b/include/cylinder.h
@@ -5,8 +5,13 @@
 # include "minirt.h"
 # include "scene.h"
 # include "vector.h"
+
 # include <stdbool.h>
 
+void	compute_cylinder_light(t_vec3 *normal, t_point3 *intersect,
+	t_color *color, t_result *result);
+t_vec3	get_cylinder_normal(t_shape *cyl, t_point3 *intersect);
+void	handle_cylinder_intersect(double t[2], t_shape *cyl, t_range range, t_result *result);
 bool	hit_cylinder(t_point3 *origin, t_vec3 *dir, t_shape *cyl, double *t);
 void	create_cylinder(t_point3 pos, t_vec3 dir, float radius, float height, t_material mat);
 

--- a/include/hierarchy.h
+++ b/include/hierarchy.h
@@ -1,0 +1,35 @@
+#ifndef HIERARCHY_H
+# define HIERARCHY_H
+
+# include "minirt.h"
+
+typedef struct s_core t_core;
+typedef struct s_shape t_shape;
+typedef struct s_img t_img;
+
+typedef struct s_rectangle
+{
+    int         height;
+    int         width;
+    int         color;
+}   t_rectangle;
+
+typedef struct s_edit_win
+{
+	t_core		*core;
+	t_shape		*shape;
+	void		*win;
+	t_img		img;
+}	t_edit_win;
+
+// UI related functions - hierarchy.c / hierarchy_utils.c
+void		render_shape_list(t_core *core);
+void    	handle_page_click(int x);
+void    	draw_edit_text(t_core *core, t_shape *shape, int y_offset);
+void		open_edit_window(t_core *core, t_shape *shape);
+int			shape_lst_size(t_shape *lst);
+void		draw_rect(t_img *img, int x, int y, t_rectangle rec);
+int			on_mouse_debug(int button, int x, int y, void *param);
+t_rectangle new_rectangle(int width, int height, int color);
+
+#endif

--- a/include/hierarchy.h
+++ b/include/hierarchy.h
@@ -33,3 +33,4 @@ int			on_mouse_debug(int button, int x, int y, void *param);
 t_rectangle new_rectangle(int width, int height, int color);
 
 #endif
+

--- a/include/hierarchy.h
+++ b/include/hierarchy.h
@@ -3,29 +3,35 @@
 
 # include "minirt.h"
 
+#define UI_BG_COLOR		0x343434
+#define UI_DARK_GRAY	0x555555
+#define UI_SHAPE_HEIGHT	50
+#define MAX_PER_PAGE	12			// Max shapes per hierarchy page
+
 typedef struct s_core t_core;
 typedef struct s_shape t_shape;
 typedef struct s_img t_img;
 
 typedef struct s_rectangle
 {
-    int         height;
-    int         width;
-    int         color;
+	int			height;
+	int			width;
+	int			color;
 }   t_rectangle;
 
-typedef struct s_edit_win
+// Represents the edit window
+typedef struct s_ewin
 {
 	t_core		*core;
 	t_shape		*shape;
 	void		*win;
 	t_img		img;
-}	t_edit_win;
+}	t_ewin;
 
 // UI related functions - hierarchy.c / hierarchy_utils.c
 void		render_shape_list(t_core *core);
-void    	handle_page_click(int x);
-void    	draw_edit_text(t_core *core, t_shape *shape, int y_offset);
+void		handle_page_click(int x);
+void		draw_edit_text(t_core *core, t_shape *shape, int y_offset);
 void		open_edit_window(t_core *core, t_shape *shape);
 int			shape_lst_size(t_shape *lst);
 void		draw_rect(t_img *img, int x, int y, t_rectangle rec);
@@ -33,4 +39,3 @@ int			on_mouse_debug(int button, int x, int y, void *param);
 t_rectangle new_rectangle(int width, int height, int color);
 
 #endif
-

--- a/include/material.h
+++ b/include/material.h
@@ -3,7 +3,7 @@
 
 # include <stdint.h>
 
-# define SKY_COLOR {0.2, 0.2, 0.2}
+# define SKY_COLOR {0.05, 0.05, 0.07}
 
 // Struct for an RGB color representation //
 typedef struct s_color

--- a/include/minirt.h
+++ b/include/minirt.h
@@ -66,11 +66,17 @@ void		img_put_pixel(t_img *img, int x, int y, t_color *color);
 
 // Rendering functions - render.c
 t_result	closest_intersect(t_point3 *origin, t_vec3 *dir, t_range t_range);
-t_color		ray_color(t_point3 origin, t_vec3 dir, t_range t_range);
+t_color		ray_color(t_point3 origin, t_vec3 dir, t_range t_range, int depth);
 int			render(void *param);
+t_vec3		get_cylinder_normal(t_shape *cyl, t_point3 *intersect);
 
 // Fast rendering functions - fast_render.c
 int			fast_render(void *param);
+
+// Reflections - reflections.c
+t_color 	compute_reflection(t_point3 *origin, t_vec3 *dir, t_result *result, int depth);
+t_color 	scale_color(t_color c, float factor);
+t_color		add_color(t_color a, t_color b);
 
 // UI related functions - hierarchy.c / hierarchy_utils.c
 int			on_mouse_debug(int button, int x, int y, void *param);

--- a/include/minirt.h
+++ b/include/minirt.h
@@ -39,6 +39,11 @@ typedef struct s_core
 	t_scene		scene;
 	int			render_mode;
 	t_render	render;
+	void		*altwin;
+	t_img		ui_img;
+	int			ui_img_init;
+	int			prevent_close;
+	int			page_idx;
 }	t_core;
 
 // Result if a ray intersects with a (for now) sphere and its closest t on that
@@ -63,9 +68,12 @@ void		img_put_pixel(t_img *img, int x, int y, t_color *color);
 t_result	closest_intersect(t_point3 *origin, t_vec3 *dir, t_range t_range);
 t_color		ray_color(t_point3 origin, t_vec3 dir, t_range t_range);
 int			render(void *param);
-int			fast_render(void *param);
 
 // Fast rendering functions - fast_render.c
-int	fast_render(void *param);
+int			fast_render(void *param);
+
+// UI related functions - hierarchy.c / hierarchy_utils.c
+int			on_mouse_debug(int button, int x, int y, void *param);
+void		render_shape_list(t_core *core);
 
 #endif //MINIRT_H

--- a/include/minirt.h
+++ b/include/minirt.h
@@ -58,7 +58,7 @@ typedef struct s_result
 
 // General functions - minirt.c
 t_core		*get_core(void);
-int			rt_kill(t_core *core, int exit_code);
+int			rt_kill(int exit_code);
 
 // MiniLibX helper functions - mlx.c
 int			init_window(void);

--- a/include/minirt.h
+++ b/include/minirt.h
@@ -68,7 +68,6 @@ void		img_put_pixel(t_img *img, int x, int y, t_color *color);
 t_result	closest_intersect(t_point3 *origin, t_vec3 *dir, t_range t_range);
 t_color		ray_color(t_point3 origin, t_vec3 dir, t_range t_range, int depth);
 int			render(void *param);
-t_vec3		get_cylinder_normal(t_shape *cyl, t_point3 *intersect);
 
 // Fast rendering functions - fast_render.c
 int			fast_render(void *param);

--- a/include/plane.h
+++ b/include/plane.h
@@ -1,0 +1,13 @@
+#ifndef PLANE_H
+# define PLANE_H
+
+# include "point3.h"
+# include "minirt.h"
+# include "scene.h"
+# include "vector.h"
+# include <stdbool.h>
+
+int	create_plane(t_point3 position, t_vec3 normal, t_material mat);
+bool hit_plane(t_point3 *origin, t_vec3 *dir, t_shape *plane, double *t);
+
+#endif

--- a/include/plane.h
+++ b/include/plane.h
@@ -7,7 +7,9 @@
 # include "vector.h"
 # include <stdbool.h>
 
-int	create_plane(t_point3 position, t_vec3 normal, t_material mat);
-bool hit_plane(t_point3 *origin, t_vec3 *dir, t_shape *plane, double *t);
+void	compute_plane_light(t_vec3 *normal, t_color *color, t_result *result);
+void	handle_plane_intersect(double t[2], t_shape *tmp, t_range range, t_result *result);
+int		create_plane(t_point3 position, t_vec3 normal, t_material mat);
+bool	hit_plane(t_point3 *origin, t_vec3 *dir, t_shape *plane, double *t);
 
 #endif

--- a/include/point3.h
+++ b/include/point3.h
@@ -18,5 +18,7 @@ typedef t_point3	t_vec3;
 t_point3	make_point3(float x, float y, float z);
 t_vec3		point3_sub(t_point3 *a, t_point3 *b);
 t_vec3		point3_scale(t_vec3 *v, double scalar);
+t_vec3		make_vec3(float x, float y, float z); // 
+
 
 #endif // POINT3_H

--- a/include/point3.h
+++ b/include/point3.h
@@ -17,6 +17,7 @@ typedef t_point3	t_vec3;
 
 t_point3	make_point3(float x, float y, float z);
 t_vec3		point3_sub(t_point3 *a, t_point3 *b);
+t_point3	point3_add(t_point3 *a, t_vec3 *b);
 t_vec3		point3_scale(t_vec3 *v, double scalar);
 t_vec3		make_vec3(float x, float y, float z); // 
 

--- a/include/point3.h
+++ b/include/point3.h
@@ -19,7 +19,5 @@ t_point3	make_point3(float x, float y, float z);
 t_vec3		point3_sub(t_point3 *a, t_point3 *b);
 t_point3	point3_add(t_point3 *a, t_vec3 *b);
 t_vec3		point3_scale(t_vec3 *v, double scalar);
-t_vec3		make_vec3(float x, float y, float z); // 
-
 
 #endif // POINT3_H

--- a/include/scene.h
+++ b/include/scene.h
@@ -25,6 +25,7 @@ typedef struct s_shape
 	float			radius;				// For spheres and cylinders
 	float			height;				// For cylinders
 	t_vec3			normal;				// For planes
+	t_vec3			direction;
 	struct s_shape	*next;
 }	t_shape;
 

--- a/include/sphere.h
+++ b/include/sphere.h
@@ -1,6 +1,7 @@
 #ifndef SPHERE_H
 # define SPHERE_H
 
+# include "minirt.h"
 # include "scene.h"
 # include "point3.h"
 # include "material.h"
@@ -8,6 +9,8 @@
 # include <stdbool.h>
 
 // Functions //
+void	compute_sphere_light(t_vec3 *normal, t_point3 *intersect, t_color *color, t_result *result);
+void		handle_sphere_intersect(double t[2], t_shape *tmp, t_range range, t_result *result);
 int		create_sphere(t_point3 position, float radius, t_material mat);
 void	print_sphere(t_shape *sphere);
 bool	hit_sphere(t_point3 *origin, t_vec3 *dir, t_shape *sphere, double *t);

--- a/src/fast_render.c
+++ b/src/fast_render.c
@@ -4,6 +4,7 @@
 #include <math.h>
 
 #define FAST_STEP 10
+#define	MAXDEPTH 3
 
 /**
  * @brief For every fast step block of pixels, output the same color as a block.
@@ -18,7 +19,7 @@ static void	process_fast_steps(void)
 	color = ray_color(
 			get_scene()->camera.position,
 			camera_to_viewport(get_core()->render.x, get_core()->render.y),
-			new_range(1, INFINITY)
+			new_range(1, INFINITY), MAXDEPTH
 			);
 	j = 0;
 	while (j < FAST_STEP && get_core()->render.y + j <= WIN_HEIGHT / 2)

--- a/src/hierarchy/hierarchy.c
+++ b/src/hierarchy/hierarchy.c
@@ -1,0 +1,166 @@
+#include "minirt.h"
+#include "mlx.h"
+#include "hierarchy.h"
+
+#include <X11/X.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#define UI_SHAPE_HEIGHT 50
+#define MAX_PER_PAGE 12
+
+// list size but for t_shape type
+
+int	shape_lst_size(t_shape *lst)
+{
+	int	i;
+
+	i = 0;
+	while (lst)
+	{
+		lst = lst->next;
+		i++;
+	}
+	return (i);
+}
+
+// Used this instead of the color struct to test out Hex codes faster.
+
+void	my_mlx_pixel_put(t_img *img, int x, int y, int color)
+{
+	char	*dst;
+
+	dst = img->addr + (y * img->line_len + x * (img->bpp / 8));
+	*(unsigned int *)dst = color;
+}
+
+/* Creates a rectangle struct, quite simple to understand i hope.
+*/
+
+t_rectangle	new_rectangle(int width, int height, int color)
+{
+	t_rectangle	rec;
+
+	rec.width = width;
+	rec.height = height;
+	rec.color = color;
+	return (rec);
+}
+
+// Draws a rectangle with a given img, coordinates and t_rectangle.
+// t_rectangle structs contain : int width, int height, int color (hex)
+
+void	draw_rect(t_img *img, int x, int y, t_rectangle rec)
+{
+	int	i;
+	int	j;
+
+	i = y;
+	while (i < y + rec.height)
+	{
+		j = x;
+		while (j < x + rec.width)
+		{
+			my_mlx_pixel_put(img, j, i, rec.color);
+			j++;
+		}
+		i++;
+	}
+}
+
+// Draws the gray rectangle and the edit button per shape 
+
+void	draw_button(t_shape *shape, t_img *img, int start, int y_offset)
+{
+	int	i;
+
+	i = 0;
+	while (shape && i++ < start)
+		shape = shape->next;
+	i = 0;
+	while (shape && i++ < MAX_PER_PAGE)
+	{
+		draw_rect(img, 0, y_offset, new_rectangle(400, 50, 0x343434));
+		draw_rect(img, 300, y_offset + 10, new_rectangle(80, 30, 0x555555));
+		y_offset += 50;
+		shape = shape->next;
+	}
+}
+
+/* Creates the ui_img image and calls every function that reprints
+	elements of the UI.
+
+	if core->ui_img_init is set, destroys the window and redoes it.
+	This avoids still reachable leaks from the UI.
+
+	render_shape_list() is first called on startup. It is also recalled
+	when changes are made, such as changing pages or even clicking
+	anywhere on the ui, this last case fixes a specific issue where
+	the window would appear pitch back when resized.
+*/ 
+
+void	render_shape_list(t_core *core)
+{
+	t_shape		*shape;
+	int			y_offset;
+	int			start;
+	t_img		*img;
+
+	img = &core->ui_img;
+	if (core->ui_img_init)
+		mlx_destroy_image(core->mlx, img->img);
+	img->img = mlx_new_image(core->mlx, 400, 615);
+	img->addr
+		= mlx_get_data_addr(img->img, &img->bpp, &img->line_len, &img->endian);
+	core->ui_img_init = 1;
+	start = core->page_idx * MAX_PER_PAGE;
+	shape = core->scene.shapes;
+	y_offset = 0;
+	draw_button(shape, img, start, y_offset);
+	draw_rect(img, 0, 600, new_rectangle(100, 15, 0x555555));
+	draw_rect(img, 300, 600, new_rectangle(100, 15, 0x555555));
+	mlx_put_image_to_window(core->mlx, core->altwin, img->img, 0, 0);
+	mlx_string_put(core->mlx, core->altwin, 20, 612, 0xFFFFFF, "< Prev");
+	mlx_string_put(core->mlx, core->altwin, 330, 612, 0xFFFFFF, "Next >");
+	draw_edit_text(core, shape, y_offset);
+}
+
+/* Main Mouse Hook for the Hierarchy
+
+	if core->ui_img_init is set, destroys the window and redoes it.
+	This avoids still reachable leaks from the UI.
+
+	render_shape_list() is first called on startup. It is also recalled
+	when changes are made, such as changing pages or even clicking
+	anywhere on the ui, this fixes a specific issue where the window
+	would appear pitch back when resized.
+
+*/ 
+
+int	on_mouse_debug(int button, int x, int y, void *param)
+{
+	t_shape	*shape;
+	int		i;
+	int		index;
+	int		block_height;
+
+	(void)param;
+	block_height = 50;
+	index = y / block_height;
+	shape = get_core()->scene.shapes;
+	if (y >= 580)
+		return (handle_page_click(x), 0);
+	index = get_core()->page_idx * MAX_PER_PAGE + (y / block_height);
+	i = 0;
+	while (shape && i++ < index)
+		shape = shape->next;
+	if (!shape)
+		return (0);
+	if (button == 1)
+	{
+		if (x >= 300 && x <= 380)
+			return (open_edit_window(get_core(), shape), 0);
+	}
+	render_shape_list(get_core());
+	return (0);
+}

--- a/src/hierarchy/hierarchy.c
+++ b/src/hierarchy/hierarchy.c
@@ -4,7 +4,6 @@
 
 #include <X11/X.h>
 #include <stdint.h>
-#include <stdio.h>
 
 #define UI_SHAPE_HEIGHT 50
 #define UI_BG_COLOR 0x343434
@@ -70,9 +69,11 @@ void	draw_rect(t_img *img, int x, int y, t_rectangle rec)
 	}
 }
 
-// Draws the gray rectangle and the edit button per shape 
-
-void	draw_button(t_shape *shape, t_img *img, int start, int y_offset)
+/*
+ * @brief Draws the gray rectangle and the edit button for all shapes on the
+ * current page
+*/
+void	draw_buttons(t_shape *shape, t_img *img, int start, int y_offset)
 {
 	int	i;
 
@@ -99,7 +100,7 @@ void	draw_button(t_shape *shape, t_img *img, int start, int y_offset)
 	when changes are made, such as changing pages or even clicking
 	anywhere on the ui, this last case fixes a specific issue where
 	the window would appear pitch back when resized.
-*/ 
+*/
 
 void	render_shape_list(t_core *core)
 {
@@ -118,7 +119,7 @@ void	render_shape_list(t_core *core)
 	start = core->page_idx * MAX_PER_PAGE;
 	shape = core->scene.shapes;
 	y_offset = 0;
-	draw_button(shape, img, start, y_offset);
+	draw_buttons(shape, img, start, y_offset);
 	draw_rect(img, 0, 600, new_rectangle(100, 15, UI_DARK_GRAY));
 	draw_rect(img, 300, 600, new_rectangle(100, 15, UI_DARK_GRAY));
 	mlx_put_image_to_window(core->mlx, core->altwin, img->img, 0, 0);
@@ -137,32 +138,29 @@ void	render_shape_list(t_core *core)
 	anywhere on the ui, this fixes a specific issue where the window
 	would appear pitch back when resized.
 
-*/ 
+*/
 
 int	on_mouse_debug(int button, int x, int y, void *param)
 {
+	t_core	*core;
 	t_shape	*shape;
 	int		i;
 	int		index;
-	int		block_height;
 
 	(void)param;
-	block_height = 50;
-	index = y / block_height;
-	shape = get_core()->scene.shapes;
-	if (y >= 580)
+	core = get_core();
+	index = y / UI_SHAPE_HEIGHT;
+	shape = core->scene.shapes;
+	if (button == 1 && y >= 580)
 		return (handle_page_click(x), 0);
-	index = get_core()->page_idx * MAX_PER_PAGE + (y / block_height);
+	index = core->page_idx * MAX_PER_PAGE + (y / UI_SHAPE_HEIGHT);
 	i = 0;
 	while (shape && i++ < index)
 		shape = shape->next;
 	if (!shape)
 		return (0);
-	if (button == 1)
-	{
-		if (x >= 300 && x <= 380)
-			return (open_edit_window(get_core(), shape), 0);
-	}
-	render_shape_list(get_core());
+	if (button == 1 && x >= 300 && x <= 380)
+		return (open_edit_window(core, shape), 0);
+	render_shape_list(core);
 	return (0);
 }

--- a/src/hierarchy/hierarchy.c
+++ b/src/hierarchy/hierarchy.c
@@ -7,6 +7,8 @@
 #include <stdio.h>
 
 #define UI_SHAPE_HEIGHT 50
+#define UI_BG_COLOR 0x343434
+#define UI_DARK_GRAY 0x555555
 #define MAX_PER_PAGE 12
 
 // list size but for t_shape type
@@ -80,8 +82,8 @@ void	draw_button(t_shape *shape, t_img *img, int start, int y_offset)
 	i = 0;
 	while (shape && i++ < MAX_PER_PAGE)
 	{
-		draw_rect(img, 0, y_offset, new_rectangle(400, 50, 0x343434));
-		draw_rect(img, 300, y_offset + 10, new_rectangle(80, 30, 0x555555));
+		draw_rect(img, 0, y_offset, new_rectangle(400, 50, UI_BG_COLOR));
+		draw_rect(img, 300, y_offset + 10, new_rectangle(80, 30, UI_DARK_GRAY));
 		y_offset += 50;
 		shape = shape->next;
 	}
@@ -117,8 +119,8 @@ void	render_shape_list(t_core *core)
 	shape = core->scene.shapes;
 	y_offset = 0;
 	draw_button(shape, img, start, y_offset);
-	draw_rect(img, 0, 600, new_rectangle(100, 15, 0x555555));
-	draw_rect(img, 300, 600, new_rectangle(100, 15, 0x555555));
+	draw_rect(img, 0, 600, new_rectangle(100, 15, UI_DARK_GRAY));
+	draw_rect(img, 300, 600, new_rectangle(100, 15, UI_DARK_GRAY));
 	mlx_put_image_to_window(core->mlx, core->altwin, img->img, 0, 0);
 	mlx_string_put(core->mlx, core->altwin, 20, 612, 0xFFFFFF, "< Prev");
 	mlx_string_put(core->mlx, core->altwin, 330, 612, 0xFFFFFF, "Next >");

--- a/src/hierarchy/hierarchy_utils.c
+++ b/src/hierarchy/hierarchy_utils.c
@@ -26,7 +26,7 @@ int	close_edit_window(t_edit_win *editwin)
 		mlx_destroy_image(editwin->core->mlx, editwin->img.img);
 	if (editwin->win)
 		mlx_destroy_window(editwin->core->mlx, editwin->win);
-	editwin->core->prevent_close = 0;
+	editwin->core->prevent_close -= 1;
 	free(editwin);
 	return (0);
 }
@@ -107,7 +107,7 @@ void	open_edit_window(t_core *core, t_shape *shape)
 		return ;
 	editwin->core = core;
 	editwin->shape = shape;
-	core->prevent_close = 1;
+	core->prevent_close += 1;
 	editwin->win = mlx_new_window(core->mlx, 400, 300, "Edit Shape");
 	editwin->img.img = mlx_new_image(core->mlx, 400, 300);
 	editwin->img.addr = mlx_get_data_addr(editwin->img.img,

--- a/src/hierarchy/hierarchy_utils.c
+++ b/src/hierarchy/hierarchy_utils.c
@@ -1,0 +1,180 @@
+#include "minirt.h"
+#include "mlx.h"
+#include "hierarchy.h"
+
+#include <X11/X.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define UI_SHAPE_HEIGHT 50
+#define MAX_PER_PAGE 12
+
+/* Closes and frees the temporary edit window
+
+	Only accessed through the "Close" button, closing with the cross on
+	the mlx window seems to cause some issues for now.
+
+	Core's prevent_close flag is used here to avoid closing miniRT
+	while the edit window is opened. Edit window(s) are not accessible
+	from core directly to avoid filling it with too much stuff.
+*/ 
+
+int	close_edit_window(t_edit_win *editwin)
+{
+	if (editwin->img.img)
+		mlx_destroy_image(editwin->core->mlx, editwin->img.img);
+	if (editwin->win)
+		mlx_destroy_window(editwin->core->mlx, editwin->win);
+	editwin->core->prevent_close = 0;
+	free(editwin);
+	return (0);
+}
+
+/* Mouse hook called in open_edit_window when an edit window is opened.
+
+	Checks for the area clicked, matches the colored
+	red and green squares buttons.
+*/ 
+
+int	on_mouse_edit(int button, int x, int y, void *param)
+{
+	t_edit_win	*editwin;
+
+	editwin = (t_edit_win *)param;
+	if (button != 1)
+		return (0);
+	if (x >= 50 && x <= 80 && y >= 40 && y <= 70)
+		editwin->shape->position.z += 0.1f;
+	else if (x >= 90 && x <= 120 && y >= 40 && y <= 70)
+		editwin->shape->position.z -= 0.1f;
+	else if (x >= 50 && x <= 80 && y >= 90 && y <= 120)
+		editwin->shape->position.y += 0.1f;
+	else if (x >= 90 && x <= 120 && y >= 90 && y <= 120)
+		editwin->shape->position.y -= 0.1f;
+	else if (x >= 50 && x <= 80 && y >= 140 && y <= 170)
+		editwin->shape->position.x += 0.1f;
+	else if (x >= 90 && x <= 120 && y >= 140 && y <= 170)
+		editwin->shape->position.x -= 0.1f;
+	else if (x >= 50 && x <= 80 && y >= 190 && y <= 220)
+		editwin->shape->radius += 0.1f;
+	else if (x >= 90 && x <= 120 && y >= 190 && y <= 220)
+		editwin->shape->radius -= 0.1f;
+	else if (x >= 300 && x <= 380 && y >= 250 && y <= 280)
+		return (close_edit_window(editwin));
+	return (0);
+}
+
+/* Draws colored rectangles for the Edit window
+
+	First one is the overall window background color.
+	Last one is the Close button.
+	everything in between is the red and green action buttons.
+*/ 
+
+void	draw_edit_win_rec(t_edit_win *editwin)
+{
+	draw_rect(&editwin->img, 0, 0, new_rectangle(400, 300, 0x343434));
+	draw_rect(&editwin->img, 50, 40, new_rectangle(30, 30, 0x56fc61));
+	draw_rect(&editwin->img, 90, 40, new_rectangle(30, 30, 0xfc5656));
+	draw_rect(&editwin->img, 50, 90, new_rectangle(30, 30, 0x56fc61));
+	draw_rect(&editwin->img, 90, 90, new_rectangle(30, 30, 0xfc5656));
+	draw_rect(&editwin->img, 50, 140, new_rectangle(30, 30, 0x56fc61));
+	draw_rect(&editwin->img, 90, 140, new_rectangle(30, 30, 0xfc5656));
+	draw_rect(&editwin->img, 50, 190, new_rectangle(30, 30, 0x56fc61));
+	draw_rect(&editwin->img, 90, 190, new_rectangle(30, 30, 0xfc5656));
+	draw_rect(&editwin->img, 300, 250, new_rectangle(80, 30, 0xCC3333));
+}
+
+/* Creates/Mallocs a new edit window
+
+	Assigns core, the wanted shape to edit, and prevents miniRT from closing.
+	
+	Calls draw_edit_win_rec() to draw all the needed rectangles.
+	
+	mlx_string_put prints string after anything else as it would be overwritten
+	otherwise.
+
+	Calls mlx_mouse_hook allow click checks on the edit window.
+*/ 
+
+void	open_edit_window(t_core *core, t_shape *shape)
+{
+	t_edit_win	*editwin;
+
+	editwin = malloc(sizeof(t_edit_win));
+	if (!editwin)
+		return ;
+	editwin->core = core;
+	editwin->shape = shape;
+	core->prevent_close = 1;
+	editwin->win = mlx_new_window(core->mlx, 400, 300, "Edit Shape");
+	editwin->img.img = mlx_new_image(core->mlx, 400, 300);
+	editwin->img.addr = mlx_get_data_addr(editwin->img.img,
+			&editwin->img.bpp, &editwin->img.line_len, &editwin->img.endian);
+	draw_edit_win_rec(editwin);
+	mlx_put_image_to_window(core->mlx, editwin->win, editwin->img.img, 0, 0);
+	mlx_string_put(core->mlx, editwin->win, 320, 270, 0xFFFFFF, "Close");
+	mlx_string_put(core->mlx, editwin->win, 130, 155, 0xFFFFFF, "X Axis");
+	mlx_string_put(core->mlx, editwin->win, 130, 105, 0xFFFFFF, "Y Axis");
+	mlx_string_put(core->mlx, editwin->win, 130, 55, 0xFFFFFF, "Z Axis");
+	mlx_string_put(core->mlx, editwin->win, 130, 205, 0xFFFFFF, "Size/Radius");
+	mlx_mouse_hook(editwin->win, on_mouse_edit, editwin);
+}
+
+/* Hard prints "Edit" and t_shape type on the Hierarchy window
+
+	The first while loops will advance in the t_shape list to reach
+	the current page/shape and print text for the right shapes.
+
+	once at the right index, it will print the wanted page, up to 12 shapes.
+	
+	We hard print those pieces of text after any other render, or the text
+	would get overwritten by rectangles. mlx_string_put doesn't require frees. 
+*/ 
+
+void	draw_edit_text(t_core *core, t_shape *shape, int y_offset)
+{
+	int	i;
+	int	start;
+
+	start = core->page_idx * MAX_PER_PAGE;
+	i = 0;
+	while (shape && i++ < start)
+		shape = shape->next;
+	i = 0;
+	while (shape && i++ < MAX_PER_PAGE)
+	{
+		mlx_string_put(core->mlx, core->altwin,
+			320, y_offset + 28, 0xFFFFFF, "Edit");
+		if (shape->type == SPHERE)
+			mlx_string_put(core->mlx, core->altwin,
+				50, y_offset + 28, 0xFFFFFF, "Sphere");
+		y_offset += 50;
+		shape = shape->next;
+	}
+}
+
+/* Checks if a page button was pressed
+
+	Increments or decrements the page if x is in the range up to max_page.
+
+	38 shapes would have a max_page of 3 (printed as 4 on the printf).
+	Pages 0 to 2 would have 12 shapes and page 3 would have 2 shapes.
+
+	once edited, rerender with render_shape_list()
+*/ 
+
+void	handle_page_click(int x)
+{
+	int	max_page;
+
+	max_page = (shape_lst_size(get_core()->scene.shapes) - 1) / MAX_PER_PAGE;
+	if (x >= 0 && x <= 100 && get_core()->page_idx > 0)
+		get_core()->page_idx--;
+	else if (x >= 300 && x <= 400 && get_core()->page_idx < max_page)
+		get_core()->page_idx++;
+	printf("Page %d/%d\n", get_core()->page_idx + 1,
+		(shape_lst_size(get_core()->scene.shapes) / MAX_PER_PAGE) + 1);
+	render_shape_list(get_core());
+}

--- a/src/hierarchy/hierarchy_utils.c
+++ b/src/hierarchy/hierarchy_utils.c
@@ -7,17 +7,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-// Hierarchy window
-#define UI_BG_COLOR 0x343434
-#define UI_SHAPE_HEIGHT 50
-#define MAX_PER_PAGE 12
-
-// Edit object window
-#define	EWIN_RED 0xfc5656
-#define EWIN_GREEN 0x56fc61
-#define EWIN_BUTTON 30
-#define EWIN_WIDTH 400
-#define EWIN_HEIGHT 300
+#define	EWIN_RED	0xfc5656
+#define EWIN_GREEN	0x56fc61
+#define EWIN_BUTTON	30
+#define EWIN_WIDTH	400
+#define EWIN_HEIGHT	300
 
 /* Closes and frees the temporary edit window
 
@@ -27,9 +21,9 @@
 	Core's prevent_close flag is used here to avoid closing miniRT
 	while the edit window is opened. Edit window(s) are not accessible
 	from core directly to avoid filling it with too much stuff.
-*/ 
+*/
 
-int	close_edit_window(t_edit_win *editwin)
+int	close_edit_window(t_ewin *editwin)
 {
 	if (editwin->img.img)
 		mlx_destroy_image(editwin->core->mlx, editwin->img.img);
@@ -44,13 +38,13 @@ int	close_edit_window(t_edit_win *editwin)
 
 	Checks for the area clicked, matches the colored
 	red and green squares buttons.
-*/ 
+*/
 
 int	on_mouse_edit(int button, int x, int y, void *param)
 {
-	t_edit_win	*editwin;
+	t_ewin	*editwin;
 
-	editwin = (t_edit_win *)param;
+	editwin = (t_ewin *)param;
 	if (button != 1)
 		return (0);
 	if (x >= 50 && x <= 80 && y >= 40 && y <= 70)
@@ -76,9 +70,9 @@ int	on_mouse_edit(int button, int x, int y, void *param)
 
 /*
 	Draws colored rectangles for the Edit window
-*/ 
+*/
 
-void	draw_edit_win_rec(t_edit_win *editwin)
+void	draw_edit_win_rec(t_ewin *editwin)
 {
 	draw_rect(&editwin->img, 0, 0, new_rectangle(EWIN_WIDTH, EWIN_HEIGHT, UI_BG_COLOR));
 	draw_rect(&editwin->img, 50, 40, new_rectangle(EWIN_BUTTON, EWIN_BUTTON, EWIN_GREEN));
@@ -95,20 +89,20 @@ void	draw_edit_win_rec(t_edit_win *editwin)
 /* Creates/Mallocs a new edit window
 
 	Assigns core, the wanted shape to edit, and prevents miniRT from closing.
-	
+
 	Calls draw_edit_win_rec() to draw all the needed rectangles.
-	
+
 	mlx_string_put prints string after anything else as it would be overwritten
 	otherwise.
 
 	Calls mlx_mouse_hook allow click checks on the edit window.
-*/ 
+*/
 
 void	open_edit_window(t_core *core, t_shape *shape)
 {
-	t_edit_win	*editwin;
+	t_ewin	*editwin;
 
-	editwin = malloc(sizeof(t_edit_win));
+	editwin = malloc(sizeof(t_ewin));
 	if (!editwin)
 		return ;
 	editwin->core = core;
@@ -134,10 +128,10 @@ void	open_edit_window(t_core *core, t_shape *shape)
 	the current page/shape and print text for the right shapes.
 
 	once at the right index, it will print the wanted page, up to 12 shapes.
-	
+
 	We hard print those pieces of text after any other render, or the text
-	would get overwritten by rectangles. mlx_string_put doesn't require frees. 
-*/ 
+	would get overwritten by rectangles. mlx_string_put doesn't require frees.
+*/
 
 void	draw_edit_text(t_core *core, t_shape *shape, int y_offset)
 {
@@ -169,7 +163,7 @@ void	draw_edit_text(t_core *core, t_shape *shape, int y_offset)
 	Pages 0 to 2 would have 12 shapes and page 3 would have 2 shapes.
 
 	once edited, rerender with render_shape_list()
-*/ 
+*/
 
 void	handle_page_click(int x)
 {

--- a/src/hierarchy/hierarchy_utils.c
+++ b/src/hierarchy/hierarchy_utils.c
@@ -168,13 +168,15 @@ void	draw_edit_text(t_core *core, t_shape *shape, int y_offset)
 void	handle_page_click(int x)
 {
 	int	max_page;
+	t_core *core;
 
-	max_page = (shape_lst_size(get_core()->scene.shapes) - 1) / MAX_PER_PAGE;
-	if (x >= 0 && x <= 100 && get_core()->page_idx > 0)
-		get_core()->page_idx--;
-	else if (x >= 300 && x <= 400 && get_core()->page_idx < max_page)
-		get_core()->page_idx++;
-	printf("Page %d/%d\n", get_core()->page_idx + 1,
-		(shape_lst_size(get_core()->scene.shapes) / MAX_PER_PAGE) + 1);
-	render_shape_list(get_core());
+	core = get_core();
+	max_page = (shape_lst_size(core->scene.shapes) - 1) / MAX_PER_PAGE;
+	if (x >= 0 && x <= 100 && core->page_idx > 0)
+		core->page_idx--;
+	else if (x >= 300 && x <= 400 && core->page_idx < max_page)
+		core->page_idx++;
+	printf("Page %d/%d\n", core->page_idx + 1,
+		(shape_lst_size(core->scene.shapes) / MAX_PER_PAGE) + 1);
+	render_shape_list(core);
 }

--- a/src/hierarchy/hierarchy_utils.c
+++ b/src/hierarchy/hierarchy_utils.c
@@ -119,7 +119,8 @@ void	open_edit_window(t_core *core, t_shape *shape)
 	mlx_string_put(core->mlx, editwin->win, 130, 105, 0xFFFFFF, "Y Axis");
 	mlx_string_put(core->mlx, editwin->win, 130, 55, 0xFFFFFF, "Z Axis");
 	mlx_string_put(core->mlx, editwin->win, 130, 205, 0xFFFFFF, "Size/Radius");
-	mlx_hook(editwin->win, DestroyNotify, 0, close_edit_window, editwin);
+	// mlx_hook(editwin->win, DestroyNotify, 0, close_edit_window, editwin);
+	// TODO: mlx shits itself when closing the edit window with the red cross
 	mlx_mouse_hook(editwin->win, on_mouse_edit, editwin);
 }
 

--- a/src/hierarchy/hierarchy_utils.c
+++ b/src/hierarchy/hierarchy_utils.c
@@ -119,6 +119,7 @@ void	open_edit_window(t_core *core, t_shape *shape)
 	mlx_string_put(core->mlx, editwin->win, 130, 105, 0xFFFFFF, "Y Axis");
 	mlx_string_put(core->mlx, editwin->win, 130, 55, 0xFFFFFF, "Z Axis");
 	mlx_string_put(core->mlx, editwin->win, 130, 205, 0xFFFFFF, "Size/Radius");
+	mlx_hook(editwin->win, DestroyNotify, 0, close_edit_window, editwin);
 	mlx_mouse_hook(editwin->win, on_mouse_edit, editwin);
 }
 

--- a/src/hierarchy/hierarchy_utils.c
+++ b/src/hierarchy/hierarchy_utils.c
@@ -7,8 +7,17 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+// Hierarchy window
+#define UI_BG_COLOR 0x343434
 #define UI_SHAPE_HEIGHT 50
 #define MAX_PER_PAGE 12
+
+// Edit object window
+#define	EWIN_RED 0xfc5656
+#define EWIN_GREEN 0x56fc61
+#define EWIN_BUTTON 30
+#define EWIN_WIDTH 400
+#define EWIN_HEIGHT 300
 
 /* Closes and frees the temporary edit window
 
@@ -65,25 +74,22 @@ int	on_mouse_edit(int button, int x, int y, void *param)
 	return (0);
 }
 
-/* Draws colored rectangles for the Edit window
-
-	First one is the overall window background color.
-	Last one is the Close button.
-	everything in between is the red and green action buttons.
+/*
+	Draws colored rectangles for the Edit window
 */ 
 
 void	draw_edit_win_rec(t_edit_win *editwin)
 {
-	draw_rect(&editwin->img, 0, 0, new_rectangle(400, 300, 0x343434));
-	draw_rect(&editwin->img, 50, 40, new_rectangle(30, 30, 0x56fc61));
-	draw_rect(&editwin->img, 90, 40, new_rectangle(30, 30, 0xfc5656));
-	draw_rect(&editwin->img, 50, 90, new_rectangle(30, 30, 0x56fc61));
-	draw_rect(&editwin->img, 90, 90, new_rectangle(30, 30, 0xfc5656));
-	draw_rect(&editwin->img, 50, 140, new_rectangle(30, 30, 0x56fc61));
-	draw_rect(&editwin->img, 90, 140, new_rectangle(30, 30, 0xfc5656));
-	draw_rect(&editwin->img, 50, 190, new_rectangle(30, 30, 0x56fc61));
-	draw_rect(&editwin->img, 90, 190, new_rectangle(30, 30, 0xfc5656));
-	draw_rect(&editwin->img, 300, 250, new_rectangle(80, 30, 0xCC3333));
+	draw_rect(&editwin->img, 0, 0, new_rectangle(EWIN_WIDTH, EWIN_HEIGHT, UI_BG_COLOR));
+	draw_rect(&editwin->img, 50, 40, new_rectangle(EWIN_BUTTON, EWIN_BUTTON, EWIN_GREEN));
+	draw_rect(&editwin->img, 90, 40, new_rectangle(EWIN_BUTTON, EWIN_BUTTON, EWIN_RED));
+	draw_rect(&editwin->img, 50, 90, new_rectangle(EWIN_BUTTON, EWIN_BUTTON, EWIN_GREEN));
+	draw_rect(&editwin->img, 90, 90, new_rectangle(EWIN_BUTTON, EWIN_BUTTON, EWIN_RED));
+	draw_rect(&editwin->img, 50, 140, new_rectangle(EWIN_BUTTON, EWIN_BUTTON, EWIN_GREEN));
+	draw_rect(&editwin->img, 90, 140, new_rectangle(EWIN_BUTTON, EWIN_BUTTON, EWIN_RED));
+	draw_rect(&editwin->img, 50, 190, new_rectangle(EWIN_BUTTON, EWIN_BUTTON, EWIN_GREEN));
+	draw_rect(&editwin->img, 90, 190, new_rectangle(EWIN_BUTTON, EWIN_BUTTON, EWIN_RED));
+	draw_rect(&editwin->img, 300, 250, new_rectangle(80, 30, 0xCC3333)); // No macro for close as we could replace it with using the cross
 }
 
 /* Creates/Mallocs a new edit window
@@ -108,8 +114,8 @@ void	open_edit_window(t_core *core, t_shape *shape)
 	editwin->core = core;
 	editwin->shape = shape;
 	core->prevent_close += 1;
-	editwin->win = mlx_new_window(core->mlx, 400, 300, "Edit Shape");
-	editwin->img.img = mlx_new_image(core->mlx, 400, 300);
+	editwin->win = mlx_new_window(core->mlx, EWIN_WIDTH, EWIN_HEIGHT, "Edit Shape");
+	editwin->img.img = mlx_new_image(core->mlx, EWIN_WIDTH, EWIN_HEIGHT);
 	editwin->img.addr = mlx_get_data_addr(editwin->img.img,
 			&editwin->img.bpp, &editwin->img.line_len, &editwin->img.endian);
 	draw_edit_win_rec(editwin);

--- a/src/minirt.c
+++ b/src/minirt.c
@@ -7,6 +7,7 @@
 #include "scene.h"
 #include "sphere.h"
 #include "plane.h"
+#include "cylinder.h"
 #include "light.h"
 #include "libft.h"
 
@@ -64,6 +65,23 @@ void	test_scene(void)
 	vec_normalize(&normalplane);
 	create_plane(make_point3(0.0, -1.0, 0.0), normalplane, make_mat(make_color(0.3, 0.3, 0.4), 1000, 0.0f));
 
+	create_cylinder(
+		make_point3(10.0, 3.0, 5.0),
+		make_vec3(0.0, 1.0, 0.0),
+		0.4,
+		3.0,
+		make_mat(make_color(1.0, 0.0, 0.0), 500, 0.5)
+	);
+	create_sphere(
+		make_point3(10.0, 6.0, 5.0),
+		0.7,
+		make_mat(make_color(1.0, 0.0, 0.0), 1000, 0.2f)
+	);
+	create_sphere(
+		make_point3(10.0, 3.0, 5.0),
+		0.7,
+		make_mat(make_color(1.0, 0.0, 0.0), 1000, 0.2f)
+	);
 	create_sphere(
 		make_point3(1.0, -1.0, 3.0),
 		1,

--- a/src/minirt.c
+++ b/src/minirt.c
@@ -6,6 +6,7 @@
 #include "point3.h"
 #include "scene.h"
 #include "sphere.h"
+#include "plane.h"
 #include "light.h"
 #include "libft.h"
 
@@ -57,6 +58,12 @@ int	rt_kill(t_core *core, int exit_code)
  */
 void	test_scene(void)
 {
+	t_vec3 normalplane; // don't mind the 3 following lines we just need a normalized vector beforehand so far.
+
+	normalplane = make_vec3(0.0, 1.0, 0.0);
+	vec_normalize(&normalplane);
+	create_plane(make_point3(0.0, -1.0, 0.0), normalplane, make_mat(make_color(0.7, 0.7, 0.7), -1, 0.0f));
+
 	create_sphere(
 		make_point3(1.0, -1.0, 3.0),
 		1,
@@ -73,12 +80,6 @@ void	test_scene(void)
 		make_mat(make_color(0.0, 0.0, 1.0), 300, 0.4f)
 	);
 
-	create_sphere(
-		make_point3(0.0, -101.0, 0.0),
-		100,
-		make_mat(make_color(0.3, 0.3, 0.3), 300, 0.5f)
-	);
-
 	for (float i = 0.0; i <= 1.0; i += 0.1)
 		create_sphere(
 			make_point3(-5.0 + (i * 10), 8.0, 20.0),
@@ -87,8 +88,8 @@ void	test_scene(void)
 		);
 
 	create_light(
-		make_point3(10.0, 20.0, 10.0),
-		1.0,
+		make_point3(-10.0, 20.0, 15.0),
+		0.6,
 		make_color(1.0, 1.0, 1.0)
 	);
 

--- a/src/minirt.c
+++ b/src/minirt.c
@@ -38,9 +38,13 @@ int	rt_kill(t_core *core, int exit_code)
 {
 	assert("Core" && core);
 	printf("[!] - Closing miniRT...\n");
+	if (core->prevent_close)
+		return (printf("[!] - Close edit Window before quitting\n"), 0);
 	clear_lights(core->scene.lights);
 	clear_shapes(core->scene.shapes);
 	mlx_destroy_image(core->mlx, core->img.img);
+	mlx_destroy_image(core->mlx, core->ui_img.img);
+	mlx_destroy_window(core->mlx, core->altwin);
 	mlx_destroy_window(core->mlx, core->win);
 	mlx_destroy_display(core->mlx);
 	free(core->mlx);
@@ -117,7 +121,10 @@ int	main(void)
 			);
 	core->render_mode = 0;
 	core->render.is_rendering = 0;
+	core->page_idx = 0;
+	core->prevent_close = 0;
 	mlx_loop_hook(core->mlx, fast_render, core);
 	printf("================\n");
+	mlx_mouse_hook(core->altwin, on_mouse_debug, core);
 	mlx_loop(get_core()->mlx);
 }

--- a/src/minirt.c
+++ b/src/minirt.c
@@ -60,52 +60,49 @@ int	rt_kill(t_core *core, int exit_code)
 void	test_scene(void)
 {
 	t_vec3 normalplane; // don't mind the 3 following lines we just need a normalized vector beforehand so far.
-	t_vec3 dangplane;
+
 	normalplane = make_vec3(0.0, 1.0, 0.0);
-	dangplane = make_vec3(0.0, 1.0, 0.0);
-	vec_normalize(&dangplane);
 	vec_normalize(&normalplane);
-	create_plane(make_point3(0.0, 15.0, 0.0), dangplane, make_mat(make_color(0.3, 0.3, 1.0), 1000, 0.0f));
-	create_plane(make_point3(0.0, -1.0, 0.0), normalplane, make_mat(make_color(0.7, 0.7, 0.7), 1000, 0.0f));
+	create_plane(make_point3(0.0, -1.0, 0.0), normalplane, make_mat(make_color(0.7, 0.7, 0.7), -1, 0.1));
 
 	create_cylinder(
 		make_point3(10.0, 1.5, 1.0),
 		make_vec3(0.0, 1.0, 0.0),
 		3.005,
 		0.5,
-		make_mat(make_color(0.0, 0.0, 0.0), 500, 0.5)
-	);
-	create_sphere(
-		make_point3(10.0, 2.0, 1.0),
-		3.0,
-		make_mat(make_color(1.0, 0.0, 0.0), 1000, 0.2f)
+		make_mat(make_color(0.0, 0.0, 0.0), 1000, 0.1)
 	);
 	create_sphere(
 		make_point3(10.0, 1.9, 1.0),
 		3.0,
-		make_mat(make_color(1.0, 1.0, 1.0), 1000, 0.2f)
+		make_mat(make_color(1.0, 0.0, 0.0), 1000, 0.1)
+	);
+	create_sphere(
+		make_point3(10.0, 1.8, 1.0),
+		3.0,
+		make_mat(make_color(1.0, 1.0, 1.0), 1000, 0.1)
 	);
 	create_sphere(
 		make_point3(1.0, -1.0, 3.0),
 		1,
-		make_mat(make_color(0.86, 1.0, 0.21), 1000, 0.2f)
+		make_mat(make_color(0.86, 1.0, 0.21), 1000, 0.1)
 	);
 	create_sphere(
 		make_point3(0.0, 0.0, 5.0),
 		1,
-		make_mat(make_color(0.0, 1.0, 0.0), 1000, 0.3f)
+		make_mat(make_color(0.0, 1.0, 0.0), 1000, 0.1)
 	);
 	create_sphere(
 		make_point3(-1.0, 1.0, 7.0),
 		1,
-		make_mat(make_color(0.0, 0.0, 1.0), 1000, 0.4f)
+		make_mat(make_color(0.0, 0.0, 1.0), 1000, 0.1)
 	);
 
 	for (float i = 0.0; i <= 1.0; i += 0.1)
 		create_sphere(
 			make_point3(-5.0 + (i * 10), 8.0, 20.0),
 			1,
-			make_mat(make_color(i, i, i), 1000, 0.5)
+			make_mat(make_color(i, i, i), 1000, 0.1)
 		);
 
 	create_light(

--- a/src/minirt.c
+++ b/src/minirt.c
@@ -62,34 +62,34 @@ void	test_scene(void)
 
 	normalplane = make_vec3(0.0, 1.0, 0.0);
 	vec_normalize(&normalplane);
-	create_plane(make_point3(0.0, -1.0, 0.0), normalplane, make_mat(make_color(0.7, 0.7, 0.7), -1, 0.0f));
+	create_plane(make_point3(0.0, -1.0, 0.0), normalplane, make_mat(make_color(0.3, 0.3, 0.4), 1000, 0.0f));
 
 	create_sphere(
 		make_point3(1.0, -1.0, 3.0),
 		1,
-		make_mat(make_color(1.0, 0.0, 0.0), 300, 0.2f)
+		make_mat(make_color(0.86, 1.0, 0.21), 1000, 0.2f)
 	);
 	create_sphere(
 		make_point3(0.0, 0.0, 5.0),
 		1,
-		make_mat(make_color(0.0, 1.0, 0.0), 300, 0.3f)
+		make_mat(make_color(0.0, 1.0, 0.0), 1000, 0.3f)
 	);
 	create_sphere(
 		make_point3(-1.0, 1.0, 7.0),
 		1,
-		make_mat(make_color(0.0, 0.0, 1.0), 300, 0.4f)
+		make_mat(make_color(0.0, 0.0, 1.0), 1000, 0.4f)
 	);
 
 	for (float i = 0.0; i <= 1.0; i += 0.1)
 		create_sphere(
 			make_point3(-5.0 + (i * 10), 8.0, 20.0),
 			1,
-			make_mat(make_color(i, i, i), 300, 0.5)
+			make_mat(make_color(i, i, i), 1000, 0.5)
 		);
 
 	create_light(
-		make_point3(-10.0, 20.0, 15.0),
-		0.6,
+		make_point3(-7.0, 10.0, 15.0),
+		0.9,
 		make_color(1.0, 1.0, 1.0)
 	);
 

--- a/src/minirt.c
+++ b/src/minirt.c
@@ -60,27 +60,30 @@ int	rt_kill(t_core *core, int exit_code)
 void	test_scene(void)
 {
 	t_vec3 normalplane; // don't mind the 3 following lines we just need a normalized vector beforehand so far.
-
+	t_vec3 dangplane;
 	normalplane = make_vec3(0.0, 1.0, 0.0);
+	dangplane = make_vec3(0.0, 1.0, 0.0);
+	vec_normalize(&dangplane);
 	vec_normalize(&normalplane);
-	create_plane(make_point3(0.0, -1.0, 0.0), normalplane, make_mat(make_color(0.3, 0.3, 0.4), 1000, 0.0f));
+	create_plane(make_point3(0.0, 15.0, 0.0), dangplane, make_mat(make_color(0.3, 0.3, 1.0), 1000, 0.0f));
+	create_plane(make_point3(0.0, -1.0, 0.0), normalplane, make_mat(make_color(0.7, 0.7, 0.7), 1000, 0.0f));
 
 	create_cylinder(
-		make_point3(10.0, 3.0, 5.0),
+		make_point3(10.0, 1.5, 1.0),
 		make_vec3(0.0, 1.0, 0.0),
-		0.4,
+		3.005,
+		0.5,
+		make_mat(make_color(0.0, 0.0, 0.0), 500, 0.5)
+	);
+	create_sphere(
+		make_point3(10.0, 2.0, 1.0),
 		3.0,
-		make_mat(make_color(1.0, 0.0, 0.0), 500, 0.5)
-	);
-	create_sphere(
-		make_point3(10.0, 6.0, 5.0),
-		0.7,
 		make_mat(make_color(1.0, 0.0, 0.0), 1000, 0.2f)
 	);
 	create_sphere(
-		make_point3(10.0, 3.0, 5.0),
-		0.7,
-		make_mat(make_color(1.0, 0.0, 0.0), 1000, 0.2f)
+		make_point3(10.0, 1.9, 1.0),
+		3.0,
+		make_mat(make_color(1.0, 1.0, 1.0), 1000, 0.2f)
 	);
 	create_sphere(
 		make_point3(1.0, -1.0, 3.0),

--- a/src/minirt.c
+++ b/src/minirt.c
@@ -63,13 +63,13 @@ void	test_scene(void)
 {
 	create_plane(
 		make_point3(0.0, -1.0, 0.0),
-		make_vec3(0.0, 1.0, 0.0),
+		(t_vec3){0.0, 1.0, 0.0},
 		make_mat(make_color(0.7, 0.7, 0.7), -1, 0.1)
 	);
 
 	create_cylinder(
 		make_point3(10.0, 1.5, 1.0),
-		make_vec3(0.0, 1.0, 0.0),
+		(t_vec3){0.0, 1.0, 0.0},
 		3.005,
 		0.5,
 		make_mat(make_color(0.0, 0.0, 0.0), 1000, 0.1)

--- a/src/minirt.c
+++ b/src/minirt.c
@@ -59,11 +59,7 @@ int	rt_kill(t_core *core, int exit_code)
  */
 void	test_scene(void)
 {
-	t_vec3 normalplane; // don't mind the 3 following lines we just need a normalized vector beforehand so far.
-
-	normalplane = make_vec3(0.0, 1.0, 0.0);
-	vec_normalize(&normalplane);
-	create_plane(make_point3(0.0, -1.0, 0.0), normalplane, make_mat(make_color(0.7, 0.7, 0.7), -1, 0.1));
+	create_plane(make_point3(0.0, -1.0, 0.0), make_vec3(0.0, 1.0, 0.0), make_mat(make_color(0.7, 0.7, 0.7), -1, 0.1));
 
 	create_cylinder(
 		make_point3(10.0, 1.5, 1.0),

--- a/src/minirt.c
+++ b/src/minirt.c
@@ -36,12 +36,14 @@ t_core	*get_core(void)
  * @brief Closes the program and cleans its heap-allocated memory.
  * Also takes care of MLX ressources.
  */
-int	rt_kill(t_core *core, int exit_code)
+int	rt_kill(int exit_code)
 {
-	assert("Core" && core);
-	printf("[!] - Closing miniRT...\n");
+	t_core	*core;
+
+	core = get_core();
 	if (core->prevent_close)
 		return (printf("[!] - Close edit Window before quitting\n"), 0);
+	printf("[!] - Closing miniRT...\n");
 	clear_lights(core->scene.lights);
 	clear_shapes(core->scene.shapes);
 	mlx_destroy_image(core->mlx, core->img.img);
@@ -59,7 +61,11 @@ int	rt_kill(t_core *core, int exit_code)
  */
 void	test_scene(void)
 {
-	create_plane(make_point3(0.0, -1.0, 0.0), make_vec3(0.0, 1.0, 0.0), make_mat(make_color(0.7, 0.7, 0.7), -1, 0.1));
+	create_plane(
+		make_point3(0.0, -1.0, 0.0),
+		make_vec3(0.0, 1.0, 0.0),
+		make_mat(make_color(0.7, 0.7, 0.7), -1, 0.1)
+	);
 
 	create_cylinder(
 		make_point3(10.0, 1.5, 1.0),
@@ -127,7 +133,7 @@ int	main(void)
 	init_window();
 	core->img.img = mlx_new_image(core->mlx, WIN_WIDTH, WIN_HEIGHT);
 	if (!core->img.img)
-		rt_kill(core, 1);
+		rt_kill(1);
 	core->img.addr = mlx_get_data_addr(
 			core->img.img,
 			&core->img.bpp,

--- a/src/mlx.c
+++ b/src/mlx.c
@@ -96,6 +96,9 @@ int	init_window(void)
 		= mlx_new_window(core->mlx, WIN_WIDTH, WIN_HEIGHT, "Obsolete Meat");
 	if (!core->win)
 		return (1);
+	core->altwin
+		= mlx_new_window(core->mlx, 400, 615, "Obsolete Meat - Hierarchy");
+	render_shape_list(core);
 	init_hooks(core);
 	return (0);
 }

--- a/src/mlx.c
+++ b/src/mlx.c
@@ -53,7 +53,7 @@ static int	key_press(int key, void *param)
 	// printf("Key pressed: %d\n", key);
 	core = param;
 	if (key == KEY_ESC)
-		return (rt_kill(core, 0));
+		return (rt_kill(0));
 	if (key == KEY_R && core->render.is_rendering == 0)
 		swap_render_mode(core);
 	if ((key == KEY_LEFT || key == KEY_A) && core->render_mode == 0)
@@ -79,7 +79,7 @@ static void	init_hooks(t_core *core)
 {
 	core = get_core();
 	mlx_hook(core->win, KeyPress, KeyPressMask, key_press, core);
-	mlx_hook(core->win, DestroyNotify, 0, rt_kill, core);
+	mlx_hook(core->win, DestroyNotify, 0, rt_kill, 0);
 }
 
 /**

--- a/src/reflections/reflections.c
+++ b/src/reflections/reflections.c
@@ -1,0 +1,85 @@
+#include "camera.h"
+#include "light.h"
+#include "minirt.h"
+#include "point3.h"
+#include "material.h"
+#include "scene.h"
+#include "sphere.h"
+#include "math.h"
+#include "mlx.h"
+#include "vector.h"
+#include "utils.h"
+#include "plane.h"
+#include "cylinder.h"
+
+#include <math.h>
+#include <stdbool.h>
+#include <assert.h>
+
+t_color	scale_color(t_color c, float factor)
+{
+	t_range	range;
+	t_color	result;
+
+	range = new_range(0.0, 1.0);
+	result.r = clamp(c.r * factor, range);
+	result.g = clamp(c.g * factor, range);
+	result.b = clamp(c.b * factor, range);
+	return (result);
+}
+
+t_color	add_color(t_color a, t_color b)
+{
+	t_range	range;
+	t_color	result;
+
+	range = new_range(0.0, 1.0);
+	result.r = clamp(a.r + b.r, range);
+	result.g = clamp(a.g + b.g, range);
+	result.b = clamp(a.b + b.b, range);
+	return (result);
+}
+
+static t_point3	get_intersection_point(t_point3 *origin, t_vec3 *dir, float t)
+{
+	t_vec3	offset;
+
+	offset = point3_scale(dir, t);
+	return (point3_add(origin, &offset));
+}
+
+static t_vec3	get_normal(t_result *result, t_point3 *point)
+{
+	t_vec3	normal;
+
+	if (result->closest->type == SPHERE)
+	{
+		normal = point3_sub(point, &result->closest->position);
+		vec_normalize(&normal);
+	}
+	else if (result->closest->type == PLANE)
+		normal = result->closest->normal;
+	else
+		normal = get_cylinder_normal(result->closest, point);
+	return (normal);
+}
+
+t_color	compute_reflection(t_point3 *origin, t_vec3 *dir, t_result *result,
+		int depth)
+{
+	t_point3	intersect;
+	t_vec3		normal;
+	t_vec3		view_dir;
+	t_vec3		reflected_dir;
+	t_color		reflected;
+
+	intersect = get_intersection_point(origin, dir, result->closest_t);
+	normal = get_normal(result, &intersect);
+	view_dir = point3_scale(dir, -1);
+	reflected_dir = reflect_ray(&view_dir, &normal);
+	if (depth <= 0 || result->closest->mat.reflection <= 0.0f)
+		return ((t_color){0, 0, 0});
+	reflected = ray_color(intersect, reflected_dir,
+			new_range(0.001f, INFINITY), depth - 1);
+	return (scale_color(reflected, result->closest->mat.reflection));
+}

--- a/src/reflections/reflections.c
+++ b/src/reflections/reflections.c
@@ -59,7 +59,7 @@ static t_vec3	get_normal(t_result *result, t_point3 *point)
 	}
 	else if (result->closest->type == PLANE)
 		normal = result->closest->normal;
-	else if (result->closest->type == CYLINDER)
+	else
 		normal = get_cylinder_normal(result->closest, point);
 	return (normal);
 }

--- a/src/reflections/reflections.c
+++ b/src/reflections/reflections.c
@@ -59,7 +59,7 @@ static t_vec3	get_normal(t_result *result, t_point3 *point)
 	}
 	else if (result->closest->type == PLANE)
 		normal = result->closest->normal;
-	else
+	else if (result->closest->type == CYLINDER)
 		normal = get_cylinder_normal(result->closest, point);
 	return (normal);
 }
@@ -77,8 +77,10 @@ t_color	compute_reflection(t_point3 *origin, t_vec3 *dir, t_result *result,
 	normal = get_normal(result, &intersect);
 	view_dir = point3_scale(dir, -1);
 	reflected_dir = reflect_ray(&view_dir, &normal);
+	// once depth reaches 0, quit reflections
 	if (depth <= 0 || result->closest->mat.reflection <= 0.0f)
 		return ((t_color){0, 0, 0});
+	// Recall ray_color recursively with lower depth until 0
 	reflected = ray_color(intersect, reflected_dir,
 			new_range(0.001f, INFINITY), depth - 1);
 	return (scale_color(reflected, result->closest->mat.reflection));

--- a/src/render.c
+++ b/src/render.c
@@ -69,6 +69,8 @@ t_result	closest_intersect(t_point3 *origin, t_vec3 *dir, t_range range)
 	return (result);
 }
 
+// TODO for myself i'm tired i'm going home, wanted to move the if else statements in seperate functions but did it on intersect instead yea gn
+
 /**
  * @brief Checks the (for now) diffuse lightning for a point of a (for now)
  * sphere, and computes that point's color with the lightning on top.

--- a/src/render.c
+++ b/src/render.c
@@ -69,7 +69,21 @@ t_result	closest_intersect(t_point3 *origin, t_vec3 *dir, t_range range)
 	return (result);
 }
 
-// TODO for myself i'm tired i'm going home, wanted to move the if else statements in seperate functions but did it on intersect instead yea gn
+/* TODO feel free to rearrange things, add static statements because the following functions were made
+	for norm and readability purposes. but they're just part of compute_light()
+*/
+void	compute_sphere_light(t_vec3 *normal, t_point3 *intersect, t_color *color, t_result *result)
+{
+	*normal = point3_sub(intersect, &result->closest->position);
+	vec_normalize(normal);
+	*color = result->closest->mat.color;
+}
+
+void	compute_plane_light(t_vec3 *normal, t_color *color, t_result *result)
+{
+	*normal = result->closest->normal;
+	*color = result->closest->mat.color;
+}
 
 /**
  * @brief Checks the (for now) diffuse lightning for a point of a (for now)
@@ -93,16 +107,9 @@ static t_color	compute_light(t_point3 *origin, t_vec3 *dir, t_result *result)
 	intersect.y += dir->y * result->closest_t;
 	intersect.z += dir->z * result->closest_t;
 	if (result->closest->type == SPHERE)
-	{
-		normal = point3_sub(&intersect, &result->closest->position);
-		vec_normalize(&normal);
-		color = result->closest->mat.color;
-	}
+		compute_sphere_light(&normal, &intersect, &color, result);
 	else if (result->closest->type == PLANE)
-	{
-		normal = result->closest->normal;
-		color = result->closest->mat.color;
-	}
+		compute_plane_light(&normal, &color, result);
 	intensity = clamp(
 			get_light_intensity(&intersect, &normal, result->closest->mat.specular),
 			new_range(0.0, 1.0));

--- a/src/render.c
+++ b/src/render.c
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <assert.h>
 
+// Reflection Depth, going over 3 barely adds anything visually
 #define MAXDEPTH 3
 
 /* TODO feel free to rearrange things, add static statements because the following functions were made
@@ -56,10 +57,6 @@ void	compute_cylinder_light(t_vec3 *normal, t_point3 *intersect,
 {
 	t_shape	*cyl;
 
-	assert("Normal" && normal);
-	assert("Intersect" && intersect);
-	assert("Color" && color);
-	assert("Result" && result);
 	cyl = result->closest;
 	*normal = get_cylinder_normal(cyl, intersect);
 	*color = cyl->mat.color;
@@ -180,17 +177,17 @@ t_color	ray_color(t_point3 origin, t_vec3 dir, t_range t_range, int depth)
 	t_result	result;
 	t_color		local_color;
 	t_color		reflected;
-	float		r;
 	
 	result = closest_intersect(&origin, &dir, t_range);
 	if (!result.closest)
 		return ((t_color)SKY_COLOR);
 	local_color = compute_light(&origin, &dir, &result);
-	r = result.closest->mat.reflection;
-	if (depth <= 0 || r <= 0.0f)
+	if (depth <= 0 || result.closest->mat.reflection <= 0.0f)
 		return local_color;
 	reflected = compute_reflection(&origin, &dir, &result, depth);
-	return (add_color(scale_color(local_color, 1 - r), reflected));
+	return (add_color(scale_color(
+		local_color, 1 - result.closest->mat.reflection)
+		, reflected));
 }
 
 /**

--- a/src/render.c
+++ b/src/render.c
@@ -20,85 +20,6 @@
 // Reflection Depth, going over 3 barely adds anything visually
 #define MAXDEPTH 3
 
-/* TODO feel free to rearrange things, add static statements because the following functions were made
-	for norm and readability purposes. but they're just part of compute_light()
-*/
-
-t_vec3	get_cylinder_normal(t_shape *cyl, t_point3 *intersect)
-{
-	t_vec3		base_to_p;
-	t_vec3		proj;
-	t_vec3		normal;
-	double		axis_height;
-
-	base_to_p = point3_sub(intersect, &cyl->position);
-	axis_height = dot_product(&base_to_p, &cyl->direction);
-	proj = point3_scale(&cyl->direction, axis_height);
-	normal = point3_sub(&base_to_p, &proj);
-	vec_normalize(&normal);
-	return (normal);
-}
-
-void	compute_sphere_light(t_vec3 *normal, t_point3 *intersect, t_color *color, t_result *result)
-{
-	*normal = point3_sub(intersect, &result->closest->position);
-	vec_normalize(normal);
-	*color = result->closest->mat.color;
-}
-
-void	compute_plane_light(t_vec3 *normal, t_color *color, t_result *result)
-{
-	*normal = result->closest->normal;
-	*color = result->closest->mat.color;
-}
-
-void	compute_cylinder_light(t_vec3 *normal, t_point3 *intersect,
-								t_color *color, t_result *result)
-{
-	t_shape	*cyl;
-
-	cyl = result->closest;
-	*normal = get_cylinder_normal(cyl, intersect);
-	*color = cyl->mat.color;
-}
-
-void		handle_plane_intersect(double t[2], t_shape *tmp, t_range range, t_result *result)
-{
-	if (is_in_range(t[0], range) && t[0] < result->closest_t)
-	{
-		result->closest = tmp;
-		result->closest_t = t[0];
-	}
-}
-
-void		handle_sphere_intersect(double t[2], t_shape *tmp, t_range range, t_result *result)
-{
-	if (is_in_range(t[0], range) && t[0] < result->closest_t)
-	{
-		result->closest = tmp;
-		result->closest_t = t[0];
-	}
-	if (is_in_range(t[1], range) && t[1] < result->closest_t)
-	{
-		result->closest = tmp;
-		result->closest_t = t[1];
-	}
-}
-
-void	handle_cylinder_intersect(double t[2], t_shape *cyl, t_range range, t_result *result)
-{
-	if (is_in_range(t[0], range) && t[0] < result->closest_t)
-	{
-		result->closest = cyl;
-		result->closest_t = t[0];
-	}
-	if (is_in_range(t[1], range) && t[1] < result->closest_t)
-	{
-		result->closest = cyl;
-		result->closest_t = t[1];
-	}
-}
-
 /**
  * @brief Computes the closest intersection between a ray starting at `origin`
  * in direction `dir`, contained within `range`.
@@ -177,7 +98,7 @@ t_color	ray_color(t_point3 origin, t_vec3 dir, t_range t_range, int depth)
 	t_result	result;
 	t_color		local_color;
 	t_color		reflected;
-	
+
 	result = closest_intersect(&origin, &dir, t_range);
 	if (!result.closest)
 		return ((t_color)SKY_COLOR);

--- a/src/scene/cylinder.c
+++ b/src/scene/cylinder.c
@@ -1,0 +1,127 @@
+#include "scene.h"
+#include "cylinder.h"
+#include <math.h>
+#include <assert.h>
+#include <stdlib.h>
+
+/**
+ *	The initial intersect calculation for a cylinder will end up with an
+	infinitely long cylinder. We check with this function if we are
+	inside the wanted "final" cylinder.
+
+	point	p = origin + dir * t
+	vector	v = p - cyl->position
+	height	h = dot(v, direction)
+
+	the shape's base is cyl->position. direction is the shape's central axis.
+	
+	with the "base position", we can make an infinite cylinder growing
+	towards "direction". with h, we can decide to only grow a certain height.
+ */
+static bool	is_inside_cylinder_height(t_point3 *origin, t_vec3 *dir,
+		t_shape *cyl, double t)
+{
+	t_point3	p;
+	t_vec3		v;
+	t_vec3		scaled;
+	double		h;
+
+	scaled = point3_scale(dir, t);
+	p = point3_add(origin, &scaled);
+	v = point3_sub(&p, &cyl->position);
+	h = dot_product(&v, &cyl->direction);
+	if (h < 0.0 || h > cyl->height)
+		return (false);
+	return (true);
+}
+/**
+ * @brief Projects supposedly normalized vector "v" on a "u" axis
+ */
+static t_vec3	project_vec(t_vec3 *v, t_vec3 *axis)
+{
+	t_vec3	proj;
+	double	dot;
+
+	dot = dot_product(v, axis);
+	proj = point3_scale(axis, dot);
+	return (proj);
+}
+
+/**
+	Computes the coefficients of the quadratic equation for cylinders.
+		(seatbelt on sweetie this one's harder)
+	Coeffs 0 1 2 indicates a, b, c
+ */
+static void	compute_cylinder_coeffs(t_vec3 *origin, t_vec3 *dir,
+					t_shape *cyl, double coeffs[3])
+{
+	t_vec3	oc;			// cylinder to origin ray
+	t_vec3	proj_d;		// direction parallel to axis
+	t_vec3	proj_oc;	// direction perpendicular to axis
+	t_vec3	d_proj;		// origin parallel to axis
+	t_vec3	oc_proj;	// oridin perpendicular to axis
+
+	// Cylinder base to oriding ray
+	oc = point3_sub(origin, &cyl->position);
+
+	// Projection of the ray's direction on the cylinder's axis
+	proj_d = project_vec(dir, &cyl->direction);
+	d_proj = point3_sub(dir, &proj_d);
+
+	// Projection of origin's vector on the axis
+	proj_oc = project_vec(&oc, &cyl->direction);
+	oc_proj = point3_sub(&oc, &proj_oc);
+
+	// Coefficients for the quadratic operation
+	coeffs[0] = dot_product(&d_proj, &d_proj);
+	coeffs[1] = 2 * dot_product(&d_proj, &oc_proj);
+	coeffs[2] = dot_product(&oc_proj, &oc_proj) - cyl->radius * cyl->radius;
+}
+
+/**
+ *	Find out if we are hitting a cylinder with our ray.
+ */
+bool	hit_cylinder(t_point3 *origin, t_vec3 *dir, t_shape *cyl, double *t)
+{
+	double	coeffs[3];
+	double	discriminant;
+	double	sqrt_disc;
+	double	a;
+	double	b;
+
+	assert("Origin" && origin);
+	assert("Direction" && dir);
+	assert("Cylinder" && cyl && cyl->type == CYLINDER);
+	assert("t" && t);
+	compute_cylinder_coeffs(origin, dir, cyl, coeffs);
+	a = coeffs[0];
+	b = coeffs[1];
+	discriminant = (b * b) - (4 * a * coeffs[2]);
+	if (discriminant < 0)
+		return (false);
+	sqrt_disc = sqrt(discriminant);
+    t[0] = (-b - sqrt_disc) / (2 * a);
+    t[1] = (-b + sqrt_disc) / (2 * a);
+    if (!is_inside_cylinder_height(origin, dir, cyl, t[0]))
+        t[0] = INFINITY;
+    if (!is_inside_cylinder_height(origin, dir, cyl, t[1]))
+        t[1] = INFINITY;
+    if (t[0] == INFINITY && t[1] == INFINITY)
+        return (false);
+    return (true);
+}
+
+void	create_cylinder(t_point3 pos, t_vec3 dir, float radius, float height, t_material mat)
+{
+	t_shape *cyl = malloc(sizeof(t_shape));
+
+	cyl->type = CYLINDER;
+	cyl->position = pos;
+	vec_normalize(&dir);
+	cyl->direction = dir;
+	cyl->radius = radius;
+	cyl->height = height;
+	cyl->mat = mat;
+	cyl->next = NULL;
+	add_shape(cyl);
+}

--- a/src/scene/cylinder.c
+++ b/src/scene/cylinder.c
@@ -14,7 +14,7 @@
 	height	h = dot(v, direction)
 
 	the shape's base is cyl->position. direction is the shape's central axis.
-	
+
 	with the "base position", we can make an infinite cylinder growing
 	towards "direction". with h, we can decide to only grow a certain height.
  */

--- a/src/scene/cylinder.c
+++ b/src/scene/cylinder.c
@@ -34,6 +34,31 @@ static bool	is_inside_cylinder_height(t_point3 *origin, t_vec3 *dir,
 		return (false);
 	return (true);
 }
+
+void	compute_cylinder_light(t_vec3 *normal, t_point3 *intersect,
+								t_color *color, t_result *result)
+{
+	t_shape	*cyl;
+
+	cyl = result->closest;
+	*normal = get_cylinder_normal(cyl, intersect);
+	*color = cyl->mat.color;
+}
+
+void	handle_cylinder_intersect(double t[2], t_shape *cyl, t_range range, t_result *result)
+{
+	if (is_in_range(t[0], range) && t[0] < result->closest_t)
+	{
+		result->closest = cyl;
+		result->closest_t = t[0];
+	}
+	if (is_in_range(t[1], range) && t[1] < result->closest_t)
+	{
+		result->closest = cyl;
+		result->closest_t = t[1];
+	}
+}
+
 /**
  * @brief Projects a supposedly normalized vector "v" on a "u" axis
  */
@@ -124,4 +149,19 @@ void	create_cylinder(t_point3 pos, t_vec3 dir, float radius, float height, t_mat
 	cyl->mat = mat;
 	cyl->next = NULL;
 	add_shape(cyl);
+}
+
+t_vec3	get_cylinder_normal(t_shape *cyl, t_point3 *intersect)
+{
+	t_vec3		base_to_p;
+	t_vec3		proj;
+	t_vec3		normal;
+	double		axis_height;
+
+	base_to_p = point3_sub(intersect, &cyl->position);
+	axis_height = dot_product(&base_to_p, &cyl->direction);
+	proj = point3_scale(&cyl->direction, axis_height);
+	normal = point3_sub(&base_to_p, &proj);
+	vec_normalize(&normal);
+	return (normal);
 }

--- a/src/scene/cylinder.c
+++ b/src/scene/cylinder.c
@@ -35,7 +35,7 @@ static bool	is_inside_cylinder_height(t_point3 *origin, t_vec3 *dir,
 	return (true);
 }
 /**
- * @brief Projects supposedly normalized vector "v" on a "u" axis
+ * @brief Projects a supposedly normalized vector "v" on a "u" axis
  */
 static t_vec3	project_vec(t_vec3 *v, t_vec3 *axis)
 {
@@ -49,7 +49,7 @@ static t_vec3	project_vec(t_vec3 *v, t_vec3 *axis)
 
 /**
 	Computes the coefficients of the quadratic equation for cylinders.
-		(seatbelt on sweetie this one's harder)
+		(put the seatbelt on sweetie this one's harder)
 	Coeffs 0 1 2 indicates a, b, c
  */
 static void	compute_cylinder_coeffs(t_vec3 *origin, t_vec3 *dir,
@@ -59,9 +59,9 @@ static void	compute_cylinder_coeffs(t_vec3 *origin, t_vec3 *dir,
 	t_vec3	proj_d;		// direction parallel to axis
 	t_vec3	proj_oc;	// direction perpendicular to axis
 	t_vec3	d_proj;		// origin parallel to axis
-	t_vec3	oc_proj;	// oridin perpendicular to axis
+	t_vec3	oc_proj;	// origin perpendicular to axis
 
-	// Cylinder base to oriding ray
+	// Cylinder base to origin ray
 	oc = point3_sub(origin, &cyl->position);
 
 	// Projection of the ray's direction on the cylinder's axis

--- a/src/scene/light.c
+++ b/src/scene/light.c
@@ -129,7 +129,7 @@ float	get_light_intensity(t_point3 *point, t_vec3 *normal, int specular)
 		if (light_dot_normal > 0)
 			intensity += tmp->intensity * light_dot_normal
 				/ (vec_len(normal) * vec_len(&point_to_light));
-		if (specular != 1)
+		if (specular != -1)
 			intensity += tmp->intensity
 				* get_specular_reflection(point, normal, &point_to_light, specular);
 		tmp = tmp->next;

--- a/src/scene/plane.c
+++ b/src/scene/plane.c
@@ -1,0 +1,45 @@
+#include "sphere.h"
+#include "scene.h"
+#include "vector.h"
+#include "minirt.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <math.h>
+#include <assert.h>
+
+bool hit_plane(t_point3 *origin, t_vec3 *dir, t_shape *plane, double *t)
+{
+	double	denom;
+	t_vec3	origin_to_plane;
+	
+	denom = dot_product(&plane->normal, dir);
+
+	if (fabs(denom) > 1e-6) // floatabsolute over 0.000001 or 10^-6
+	{
+		origin_to_plane = point3_sub(&plane->position, origin);
+		*t = dot_product(&origin_to_plane, &plane->normal) / denom;
+		return (*t >= 0);
+	}
+	return false;
+}
+
+int	create_plane(t_point3 position, t_vec3 normal, t_material mat)
+{
+	t_shape		*plane;
+
+	assert("Material" && mat.color.r >= 0.0f && mat.color.r <= 1.0f
+		&& mat.color.g >= 0.0f && mat.color.g <= 1.0f
+		&& mat.color.b >= 0.0f && mat.color.b <= 1.0f);
+	plane = malloc(sizeof(t_shape));
+	if (!plane)
+		return (perror("miniRT (create_plane) - malloc"), 1);
+	plane->type = PLANE;
+	plane->position = position;
+    plane->normal = normal;
+	plane->mat= mat;
+	plane->next = NULL;
+	add_shape(plane);
+	return (0);
+}

--- a/src/scene/plane.c
+++ b/src/scene/plane.c
@@ -10,7 +10,7 @@
 #include <assert.h>
 
 /**
- *	Find out if we are hitting a plane with our ray.
+ *	Find out if we are hitting a cylinder with our ray.
  */
 bool hit_plane(t_point3 *origin, t_vec3 *dir, t_shape *plane, double *t)
 {
@@ -38,6 +38,7 @@ int	create_plane(t_point3 position, t_vec3 normal, t_material mat)
 	plane = malloc(sizeof(t_shape));
 	if (!plane)
 		return (perror("miniRT (create_plane) - malloc"), 1);
+	vec_normalize(&normal);
 	plane->type = PLANE;
 	plane->position = position;
     plane->normal = normal;

--- a/src/scene/plane.c
+++ b/src/scene/plane.c
@@ -10,7 +10,7 @@
 #include <assert.h>
 
 /**
- *	Find out if we are hitting a cylinder with our ray.
+ *	Find out if we are hitting a plane with our ray.
  */
 bool hit_plane(t_point3 *origin, t_vec3 *dir, t_shape *plane, double *t)
 {

--- a/src/scene/plane.c
+++ b/src/scene/plane.c
@@ -9,6 +9,9 @@
 #include <math.h>
 #include <assert.h>
 
+/**
+ *	Find out if we are hitting a plane with our ray.
+ */
 bool hit_plane(t_point3 *origin, t_vec3 *dir, t_shape *plane, double *t)
 {
 	double	denom;

--- a/src/scene/plane.c
+++ b/src/scene/plane.c
@@ -9,6 +9,21 @@
 #include <math.h>
 #include <assert.h>
 
+void	compute_plane_light(t_vec3 *normal, t_color *color, t_result *result)
+{
+	*normal = result->closest->normal;
+	*color = result->closest->mat.color;
+}
+
+void		handle_plane_intersect(double t[2], t_shape *tmp, t_range range, t_result *result)
+{
+	if (is_in_range(t[0], range) && t[0] < result->closest_t)
+	{
+		result->closest = tmp;
+		result->closest_t = t[0];
+	}
+}
+
 /**
  *	Find out if we are hitting a plane with our ray.
  */
@@ -16,7 +31,7 @@ bool hit_plane(t_point3 *origin, t_vec3 *dir, t_shape *plane, double *t)
 {
 	double	denom;
 	t_vec3	origin_to_plane;
-	
+
 	denom = dot_product(&plane->normal, dir);
 
 	if (fabs(denom) > 1e-6) // floatabsolute over 0.000001 or 10^-6

--- a/src/scene/sphere.c
+++ b/src/scene/sphere.c
@@ -1,12 +1,35 @@
 #include "sphere.h"
 #include "scene.h"
 #include "vector.h"
+#include "minirt.h"
 
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>
 #include <math.h>
 #include <assert.h>
+
+void	compute_sphere_light(t_vec3 *normal, t_point3 *intersect, t_color *color, t_result *result)
+{
+	*normal = point3_sub(intersect, &result->closest->position);
+	vec_normalize(normal);
+	*color = result->closest->mat.color;
+}
+
+void		handle_sphere_intersect(double t[2], t_shape *tmp, t_range range, t_result *result)
+{
+	if (is_in_range(t[0], range) && t[0] < result->closest_t)
+	{
+		result->closest = tmp;
+		result->closest_t = t[0];
+	}
+	if (is_in_range(t[1], range) && t[1] < result->closest_t)
+	{
+		result->closest = tmp;
+		result->closest_t = t[1];
+	}
+}
+
 
 /**
  * @brief Adds a new sphere element to the miniRT scene.

--- a/src/utils/point3.c
+++ b/src/utils/point3.c
@@ -27,6 +27,16 @@ t_vec3	point3_sub(t_point3 *a, t_point3 *b)
 	return (vec);
 }
 
+t_point3	point3_add(t_point3 *a, t_vec3 *b)
+{
+	t_point3	result;
+
+	result.x = a->x + b->x;
+	result.y = a->y + b->y;
+	result.z = a->z + b->z;
+	return (result);
+}
+
 /**
  * @brief Scale a vector or point by a scalar value.
  */

--- a/src/utils/point3.c
+++ b/src/utils/point3.c
@@ -39,3 +39,12 @@ t_vec3	point3_scale(t_vec3 *v, double scalar)
 	vec.z = v->z * scalar;
 	return (vec);
 }
+
+t_vec3 make_vec3(float x, float y, float z)
+{
+	t_vec3 v;
+	v.x = x;
+	v.y = y;
+	v.z = z;
+	return v;
+}

--- a/src/utils/point3.c
+++ b/src/utils/point3.c
@@ -49,12 +49,3 @@ t_vec3	point3_scale(t_vec3 *v, double scalar)
 	vec.z = v->z * scalar;
 	return (vec);
 }
-
-t_vec3 make_vec3(float x, float y, float z)
-{
-	t_vec3 v;
-	v.x = x;
-	v.y = y;
-	v.z = z;
-	return v;
-}


### PR DESCRIPTION
# Branch featuring work done during vacations

## Intersections

in ``t_result closest_intersect()``, I have added intersect handlers for each shape. The ray goes through the list of shapes, checks the type and if the ray hits an object. If it does hit, result will, just as it did for the spheres, return the closest object the ray found. Which means each shapes now also have their own functions for being hit by the ray :

``bool	hit_sphere(t_point3 *origin, t_vec3 *dir, t_shape *sphere, double *t);``
``bool	hit_plane(t_point3 *origin, t_vec3 *dir, t_shape *plane, double *t);``
``bool	hit_cylinder(t_point3 *origin, t_vec3 *dir, t_shape *cyl, double *t);``

The following functions that are responsible for handling intersections are still within ``render.c`` and shall be moved to either a file for their respective shape type or another file meant for intersections :

``void	handle_sphere_intersect(double t[2], t_shape *tmp, t_range range, t_result *result);``
``void	handle_plane_intersect(double t[2], t_shape *tmp, t_range range, t_result *result);``
``void	handle_cylinder_intersect(double t[2], t_shape *cyl, t_range range, t_result *result);``

## Computing lights

I changed the old ``compute_light()`` so that it applies different changes to the normal and color depending on the closest hit shape. Depending on the closest shape, ``compute_light()`` will call one of the following functions before going through ``get_light_intensity()`` :

``void	compute_sphere_light(t_vec3 *normal, t_point3 *intersect, t_color *color, t_result *result);``
``void	compute_plane_light(t_vec3 *normal, t_color *color, t_result *result);``
``void	compute_cylinder_light(t_vec3 *normal, t_point3 *intersect, t_color *color, t_result *result);``

## Planes

Planes take the following arguments to be created

- ``position``, t_point3
- ``normal``, a normalized vector of type t_vec3
- ``mat``, t_material

The plane's normal vector gets normalized upon the creation of the plane, might not be needed but it's there if needed after parsing.

As said earlier, to render it, the ray just checks if the plane is the closest shape to render and then light gets computed on the rendering pixel differently depending on the shape hit. And that would be the same for cylinders.

## Cylinders

Cylinders take the following arguments to be created

- ``pos``, t_point3
- ``dir``, t_vec3
- ``radius``, float
- ``height``, float
- ``mat``, t_material

(Yes that is 5 arguments, we'll have to make a stupid sub structure to pass it ``to create_cylinder()``)

I also just noticed inconsistencies in naming variables pos or position on different shapes, let's discuss to fix that as well.

One thing to note I personally didn't know before doing cylinders, it's only the shape that must be done, the top and base of the cylinders are not filled.

Cylinders are more complicated than the other shapes so I'll sum things up simply. To check if we are hitting a cylinder we need to fill its equation requirements with ``compute_cylinder_coeffs()``. This lets us find two equations solutions for each ray traced. There are two solutions just like spheres do, one when we enter the cylinder and another one when we get out of it.

What makes cylinders special is the height. We first must consider cylinders as infinitely tall. Then, when checking if a cylinder is hit, we use ``is_inside_cylinder_height()`` to check if our ray hits the cylinder at a _true acceptable_ height.

Using the ``origin`` point, the ``dir`` vector and scaling it with our equation result, we get a value ``h`` that must be between ``0.0`` and ``cyl->height``. If it's over our wanted cylinder's height, it will consider it as not hit and therefore check for other shapes behind or just render SKY_COLOR.


## Reflections

Ray color now has a new argument : ``depth``

Depth is the amount of times the ray will reflect on objects, starting from 3 going down until it reaches 0.

Calling ray_color will now try to compute reflections after computing lights. The color before calculating reflections is now stored in a value called ``local_color``.

``compute_reflections()`` assigns values it needs for tracing new rays. It checks if depths hasn't reached 0 yet or if there's no reflections to be made.

Starting from MAX_DEPTH (3), rays will reflect recursively 3 times and then apply the color found after reaching 0.

Going for more than 3 reflections isn't really useful, as it would cause lag and not much more improvement visually.

We need to check further and test the ``0.0 - 1.0`` range for reflections, as we are still doing 3 reflects per ray on all occasion. we could scale it differently if really needed.

UI now needs options to edit planes and cylinders.

(gtg rn i hope i didn't miss anything)

:3