### PR TITLE
Camera rotation and smoother movements.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ CFILES		=	$(SRCDIR)/minirt.c \
 				$(SRCDIR)/scene/sphere.c \
 				$(SRCDIR)/scene/plane.c \
 				$(SRCDIR)/scene/cylinder.c \
+				$(SRCDIR)/movement/camera_movement.c \
+				$(SRCDIR)/movement/camera_rotation.c \
 				$(SRCDIR)/hierarchy/hierarchy.c \
 				$(SRCDIR)/hierarchy/hierarchy_utils.c \
 				$(SRCDIR)/hierarchy/hierarchy_sphere.c \
@@ -42,6 +44,7 @@ IFILES		=	$(INCLDIR)/minirt.h \
 				$(INCLDIR)/scene.h \
 				$(INCLDIR)/utils.h \
 				$(INCLDIR)/hierarchy.h \
+				$(INCLDIR)/movement.h \
 				$(INCLDIR)/vector.h
 
 LIBFT_DIR	=	./libft

--- a/include/camera.h
+++ b/include/camera.h
@@ -7,11 +7,16 @@ typedef struct s_camera
 {
 	t_point3	position;
 	t_vec3		direction;
+	t_vec3		up;
+	t_vec3		right;
+	t_vec3		forward;
+	float		pitch;
 	float		fov;		// Range [0, 180]
 }	t_camera;
 
 void	create_camera(t_point3 position, t_vec3 direction, float fov);
 void	print_camera(t_camera *camera);
 t_vec3	camera_to_viewport(int x, int y);
+t_vec3 camera_apply_rotation(t_vec3 v, t_camera *cam);
 
 #endif // CAMERA_H

--- a/include/minirt.h
+++ b/include/minirt.h
@@ -2,8 +2,8 @@
 # define MINIRT_H
 
 // Macros //
-# define WIN_WIDTH 2160
-# define WIN_HEIGHT 2160
+# define WIN_WIDTH 1080
+# define WIN_HEIGHT 1080
 # define BLOCK_SIZE 480
 
 // Includes //

--- a/include/minirt.h
+++ b/include/minirt.h
@@ -2,8 +2,8 @@
 # define MINIRT_H
 
 // Macros //
-# define WIN_WIDTH 1080
-# define WIN_HEIGHT 1080
+# define WIN_WIDTH 2160
+# define WIN_HEIGHT 2160
 # define BLOCK_SIZE 480
 
 // Includes //
@@ -44,6 +44,7 @@ typedef struct s_core
 	int			ui_img_init;
 	int			prevent_close;
 	int			page_idx;
+	int			key_state[256];
 }	t_core;
 
 // Result if a ray intersects with a (for now) sphere and its closest t on that
@@ -63,6 +64,8 @@ int			rt_kill(int exit_code);
 // MiniLibX helper functions - mlx.c
 int			init_window(void);
 void		img_put_pixel(t_img *img, int x, int y, t_color *color);
+void		update_camera(t_core *core);
+
 
 // Rendering functions - render.c
 t_result	closest_intersect(t_point3 *origin, t_vec3 *dir, t_range t_range);

--- a/include/movement.h
+++ b/include/movement.h
@@ -1,0 +1,27 @@
+#include <math.h>
+
+#define KEY_A 97
+#define KEY_D 100
+#define KEY_E 101
+#define KEY_Q 113
+#define KEY_R 114
+#define KEY_S 115
+#define KEY_W 119
+#define KEY_L 108
+#define KEY_J 106
+#define KEY_I 105
+#define KEY_K 107
+#define KEY_ESC 65307
+#define KEY_LEFT 65361
+#define KEY_UP 65362
+#define KEY_RIGHT 65363
+#define KEY_DOWN 65364
+#define MOVE_INTERVAL 0.35
+#define	ROTATE_ANGLE 0.03
+
+#define MAX_PITCH_RAD (M_PI / 2.0 - 0.01) // 89.4 max
+#define MIN_PITCH_RAD (-M_PI / 2.0 + 0.01)
+
+void	update_camera(t_core *core);
+void	rotate_camera_yaw(t_camera *cam, float angle);
+void	rotate_camera_pitch(t_camera *cam, float angle);

--- a/include/vector.h
+++ b/include/vector.h
@@ -8,5 +8,8 @@ t_vec3	cross_product(t_vec3 *v1, t_vec3 *v2);
 double	vec_len(t_vec3 *v);
 void	vec_normalize(t_vec3 *v);
 double	vec_cos(t_vec3 *v1, t_vec3 *v2);
+t_vec3  vec_add(t_vec3 v1, t_vec3 v2);
+t_vec3  vec_scalar(t_vec3 v, float scalar);
+
 
 #endif // VECTOR_H

--- a/src/fast_render.c
+++ b/src/fast_render.c
@@ -46,6 +46,7 @@ static void	process_fast_steps(void)
 int	fast_render(void *param)
 {
 	(void)param;
+	update_camera(get_core());
 	get_core()->render.y = -WIN_HEIGHT / 2;
 	while (get_core()->render.y <= WIN_HEIGHT / 2)
 	{

--- a/src/fast_render.c
+++ b/src/fast_render.c
@@ -1,5 +1,6 @@
 #include "minirt.h"
 #include "mlx.h"
+#include "movement.h"
 
 #include <math.h>
 

--- a/src/fast_render.c
+++ b/src/fast_render.c
@@ -18,7 +18,9 @@ static void	process_fast_steps(void)
 
 	color = ray_color(
 			get_scene()->camera.position,
+			camera_apply_rotation(
 			camera_to_viewport(get_core()->render.x, get_core()->render.y),
+			&get_scene()->camera),
 			new_range(1, INFINITY), MAXDEPTH
 			);
 	j = 0;

--- a/src/fast_render.c
+++ b/src/fast_render.c
@@ -3,7 +3,7 @@
 
 #include <math.h>
 
-#define FAST_STEP 20
+#define FAST_STEP 10
 #define	MAXDEPTH 3
 
 /**

--- a/src/minirt.c
+++ b/src/minirt.c
@@ -117,7 +117,7 @@ void	test_scene(void)
 
 	create_camera(
 		make_point3(0.0, 0.0, 0.0),
-		make_point3(1.0, 0.0, 0.0),
+		make_point3(0.0, 0.0, 1.0),
 		90.0
 	);
 }

--- a/src/mlx.c
+++ b/src/mlx.c
@@ -58,8 +58,11 @@ t_vec3 rotate_vector(t_vec3 v, t_vec3 axis, float angle)
 	u = axis;
     vec_normalize(&u);
     return (
-		vec_add(vec_add(vec_scalar(v, cos(angle)),
-		vec_scalar(cross_product(&u, &v), sin(angle))),
+		vec_add(
+			vec_add(
+				vec_scalar(v, cos(angle)),
+				vec_scalar(cross_product(&u, &v), sin(angle))
+			),
 		vec_scalar(u, dot_product(&u, &v) * (1 - cos(angle))))
 	);
 }

--- a/src/mlx.c
+++ b/src/mlx.c
@@ -24,8 +24,8 @@
 #define KEY_UP 65362
 #define KEY_RIGHT 65363
 #define KEY_DOWN 65364
-#define MOVE_INTERVAL 0.3
-#define	ROTATE_ANGLE 0.1
+#define MOVE_INTERVAL 0.2
+#define	ROTATE_ANGLE 0.033
 
 #define MAX_PITCH_RAD (M_PI / 2.0 - 0.01) // 89.4 max
 #define MIN_PITCH_RAD (-M_PI / 2.0 + 0.01)
@@ -105,37 +105,71 @@ void rotate_camera_yaw(t_camera *cam, float angle)
  * @brief MLX trigger for key presses, closing the window when `ESC`
  * or movement keys are pressed.
  */
-static int	key_press(int key, void *param)
-{
-	t_core	*core;
 
-	// printf("Key pressed: %d\n", key);
+ /*
+	NEW MOVEMENT, Will refactor comments later but here's the brief.
+
+	Core has a key_state int array that contains the status of each key pressed,
+	up to 256 because most key codes are in that range (damn you ESC and Arrow keys).
+
+	key_press sets the state to 1 when pressed/held, and key_release() sets it back
+	to 0.
+
+	update_camera() is called in the fast render loop, applying the movements depending
+	on the key_state value of each key.
+ */
+
+static int key_press(int key, void *param)
+{
+    t_core *core;
+	
 	core = param;
 	if (key == KEY_ESC)
-		return (rt_kill(0));
+		rt_kill(0);
 	if (key == KEY_R && core->render.is_rendering == 0)
 		swap_render_mode(core);
-	if ((key == KEY_LEFT || key == KEY_A) && core->render_mode == 0)
-		core->scene.camera.position = vec_add(core->scene.camera.position, vec_scalar(core->scene.camera.right, -MOVE_INTERVAL));
-	if ((key == KEY_RIGHT || key == KEY_D) && core->render_mode == 0)
-		core->scene.camera.position = vec_add(core->scene.camera.position, vec_scalar(core->scene.camera.right, MOVE_INTERVAL));
-	if ((key == KEY_UP || key == KEY_E) && core->render_mode == 0)
+    if (key >= 0 && key < 256)
+        core->key_state[key] = 1;
+    return (0);
+}
+
+static int key_release(int key, void *param)
+{
+    t_core *core;
+	
+	core = param;
+    if (key >= 0 && key < 256)
+        core->key_state[key] = 0;
+    return (0);
+}
+
+
+void	update_camera(t_core *core)
+{
+	if (core->key_state[KEY_A] && core->render_mode == 0)
+		core->scene.camera.position = vec_add(core->scene.camera.position,
+		vec_scalar(core->scene.camera.right, -MOVE_INTERVAL));
+	if (core->key_state[KEY_D] && core->render_mode == 0)
+		core->scene.camera.position = vec_add(core->scene.camera.position,
+		vec_scalar(core->scene.camera.right, MOVE_INTERVAL));
+	if (core->key_state[KEY_E] && core->render_mode == 0)
 		core->scene.camera.position.y += MOVE_INTERVAL;
-	if ((key == KEY_DOWN || key == KEY_Q) && core->render_mode == 0)
+	if (core->key_state[KEY_Q] && core->render_mode == 0)
 		core->scene.camera.position.y -= MOVE_INTERVAL;
-	if (key == KEY_W && core->render_mode == 0)
-		core->scene.camera.position = vec_add(vec_scalar(core->scene.camera.forward, MOVE_INTERVAL), core->scene.camera.position);
-	if (key == KEY_S && core->render_mode == 0)
-		core->scene.camera.position = vec_add(core->scene.camera.position, vec_scalar(core->scene.camera.forward, -MOVE_INTERVAL));
-	if (key == KEY_H && core->render_mode == 0)
+	if (core->key_state[KEY_W] && core->render_mode == 0)
+		core->scene.camera.position = vec_add(vec_scalar(core->scene.camera.forward, MOVE_INTERVAL),
+		core->scene.camera.position);
+	if (core->key_state[KEY_S] && core->render_mode == 0)
+		core->scene.camera.position = vec_add(core->scene.camera.position,
+		vec_scalar(core->scene.camera.forward, -MOVE_INTERVAL));
+	if (core->key_state[KEY_H] && core->render_mode == 0)
 		rotate_camera_yaw(&core->scene.camera, -ROTATE_ANGLE);
-	if (key == KEY_L && core->render_mode == 0)
+	if (core->key_state[KEY_L] && core->render_mode == 0)
 		rotate_camera_yaw(&core->scene.camera, ROTATE_ANGLE);
-	if (key == KEY_I && core->render_mode == 0)
+	if (core->key_state[KEY_I] && core->render_mode == 0)
 		rotate_camera_pitch(&core->scene.camera, -ROTATE_ANGLE);
-	if (key == KEY_K && core->render_mode == 0)
+	if (core->key_state[KEY_K] && core->render_mode == 0)
 		rotate_camera_pitch(&core->scene.camera, ROTATE_ANGLE);
-	return (0);
 }
 
 /**
@@ -146,6 +180,7 @@ static void	init_hooks(t_core *core)
 {
 	core = get_core();
 	mlx_hook(core->win, KeyPress, KeyPressMask, key_press, core);
+	mlx_hook(core->win, KeyRelease, KeyReleaseMask, key_release, core);
 	mlx_hook(core->win, DestroyNotify, 0, rt_kill, 0);
 }
 

--- a/src/mlx.c
+++ b/src/mlx.c
@@ -24,8 +24,8 @@
 #define KEY_UP 65362
 #define KEY_RIGHT 65363
 #define KEY_DOWN 65364
-#define MOVE_INTERVAL 0.2
-#define	ROTATE_ANGLE 0.033
+#define MOVE_INTERVAL 0.08
+#define	ROTATE_ANGLE 0.016
 
 #define MAX_PITCH_RAD (M_PI / 2.0 - 0.01) // 89.4 max
 #define MIN_PITCH_RAD (-M_PI / 2.0 + 0.01)
@@ -67,12 +67,9 @@ t_vec3 rotate_vector(t_vec3 v, t_vec3 axis, float angle)
 
 void	camera_build_basis(t_camera *cam)
 {
-	t_vec3 world_up;
-	
-	world_up = make_point3(0, 1, 0);
 	cam->forward = cam->direction;
 	vec_normalize(&cam->forward);
-	cam->right = cross_product(&world_up, &cam->forward);
+	cam->right = cross_product(&(t_point3){0, 1, 0}, &cam->forward);
 	vec_normalize(&cam->right);
 	cam->up = cross_product(&cam->forward, &cam->right);
 	vec_normalize(&cam->up);
@@ -88,10 +85,8 @@ void rotate_camera_pitch(t_camera *cam, float angle)
         angle = MAX_PITCH_RAD - cam->pitch;
     else if (new_pitch < MIN_PITCH_RAD)
         angle = MIN_PITCH_RAD - cam->pitch;
-
     cam->direction = rotate_vector(cam->direction, cam->right, angle);
     cam->pitch += angle;
-
     camera_build_basis(cam);
 }
 

--- a/src/mlx.c
+++ b/src/mlx.c
@@ -2,33 +2,13 @@
 #include "minirt.h"
 #include "mlx.h"
 #include "vector.h"
+#include "movement.h"
 
 #include <X11/X.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <math.h>
 
-#define KEY_A 97
-#define KEY_D 100
-#define KEY_E 101
-#define KEY_Q 113
-#define KEY_R 114
-#define KEY_S 115
-#define KEY_W 119
-#define KEY_L 108
-#define KEY_J 106
-#define KEY_I 105
-#define KEY_K 107
-#define KEY_ESC 65307
-#define KEY_LEFT 65361
-#define KEY_UP 65362
-#define KEY_RIGHT 65363
-#define KEY_DOWN 65364
-#define MOVE_INTERVAL 0.35
-#define	ROTATE_ANGLE 0.03
-
-#define MAX_PITCH_RAD (M_PI / 2.0 - 0.01) // 89.4 max
-#define MIN_PITCH_RAD (-M_PI / 2.0 + 0.01)
 /**
  * @brief Swaps miniRT between full render and fast render modes.
  */
@@ -51,70 +31,20 @@ void	swap_render_mode(t_core *core)
 		mlx_loop_hook(core->mlx, render, core);
 }
 
-t_vec3 rotate_vector(t_vec3 v, t_vec3 axis, float angle)
-{
-    t_vec3 u;
-	
-	u = axis;
-    vec_normalize(&u);
-    return (
-		vec_add(
-			vec_add(
-				vec_scalar(v, cos(angle)),
-				vec_scalar(cross_product(&u, &v), sin(angle))
-			),
-		vec_scalar(u, dot_product(&u, &v) * (1 - cos(angle))))
-	);
-}
-
-
-void	camera_build_basis(t_camera *cam)
-{
-	cam->forward = cam->direction;
-	vec_normalize(&cam->forward);
-	cam->right = cross_product(&(t_point3){0, 1, 0}, &cam->forward);
-	vec_normalize(&cam->right);
-	cam->up = cross_product(&cam->forward, &cam->right);
-	vec_normalize(&cam->up);
-}
-
-void rotate_camera_pitch(t_camera *cam, float angle)
-{
-    float new_pitch;
-	
-	new_pitch = cam->pitch + angle;
-    // Clamp avoiding clipping
-    if (new_pitch > MAX_PITCH_RAD)
-        angle = MAX_PITCH_RAD - cam->pitch;
-    else if (new_pitch < MIN_PITCH_RAD)
-        angle = MIN_PITCH_RAD - cam->pitch;
-    cam->direction = rotate_vector(cam->direction, cam->right, angle);
-    cam->pitch += angle;
-    camera_build_basis(cam);
-}
-
-void rotate_camera_yaw(t_camera *cam, float angle)
-{
-    cam->direction = rotate_vector(cam->direction, cam->up, angle);
-    camera_build_basis(cam);
-}
-
 /**
  * @brief MLX trigger for key presses, closing the window when `ESC`
  * or movement keys are pressed.
  */
 
  /*
-	NEW MOVEMENT, Will refactor comments later but here's the brief.
-
-	Core has a key_state int array that contains the status of each key pressed,
+	Core has a key_state int[256] array that contains the status of each key pressed,
 	up to 256 because most key codes are in that range (damn you ESC and Arrow keys).
 
 	key_press sets the state to 1 when pressed/held, and key_release() sets it back
 	to 0.
 
-	update_camera() is called in the fast render loop, applying the movements depending
-	on the key_state value of each key.
+	update_camera() from camera_movement.c is called in the fast render loop,
+	applying the movements depending on the key_state value of each key.
  */
 
 static int key_press(int key, void *param)
@@ -141,38 +71,9 @@ static int key_release(int key, void *param)
     return (0);
 }
 
-
-void	update_camera(t_core *core)
-{
-	if (core->key_state[KEY_A] && core->render_mode == 0)
-		core->scene.camera.position = vec_add(core->scene.camera.position,
-		vec_scalar(core->scene.camera.right, -MOVE_INTERVAL));
-	if (core->key_state[KEY_D] && core->render_mode == 0)
-		core->scene.camera.position = vec_add(core->scene.camera.position,
-		vec_scalar(core->scene.camera.right, MOVE_INTERVAL));
-	if (core->key_state[KEY_E] && core->render_mode == 0)
-		core->scene.camera.position.y += MOVE_INTERVAL;
-	if (core->key_state[KEY_Q] && core->render_mode == 0)
-		core->scene.camera.position.y -= MOVE_INTERVAL;
-	if (core->key_state[KEY_W] && core->render_mode == 0)
-		core->scene.camera.position = vec_add(vec_scalar(core->scene.camera.forward, MOVE_INTERVAL),
-		core->scene.camera.position);
-	if (core->key_state[KEY_S] && core->render_mode == 0)
-		core->scene.camera.position = vec_add(core->scene.camera.position,
-		vec_scalar(core->scene.camera.forward, -MOVE_INTERVAL));
-	if (core->key_state[KEY_J] && core->render_mode == 0)
-		rotate_camera_yaw(&core->scene.camera, -ROTATE_ANGLE);
-	if (core->key_state[KEY_L] && core->render_mode == 0)
-		rotate_camera_yaw(&core->scene.camera, ROTATE_ANGLE);
-	if (core->key_state[KEY_I] && core->render_mode == 0)
-		rotate_camera_pitch(&core->scene.camera, -ROTATE_ANGLE);
-	if (core->key_state[KEY_K] && core->render_mode == 0)
-		rotate_camera_pitch(&core->scene.camera, ROTATE_ANGLE);
-}
-
 /**
- * @brief Creates hooks for the minilibX, quitting the program when the main
- * window is destroyed or the `ESC` key is pressed.
+ * @brief Creates hooks for the minilibX, listens for keypresses,
+	key releases and the closing button 
  */
 static void	init_hooks(t_core *core)
 {

--- a/src/mlx.c
+++ b/src/mlx.c
@@ -1,10 +1,12 @@
 #include "material.h"
 #include "minirt.h"
 #include "mlx.h"
+#include "vector.h"
 
 #include <X11/X.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <math.h>
 
 #define KEY_A 97
 #define KEY_D 100
@@ -13,13 +15,20 @@
 #define KEY_R 114
 #define KEY_S 115
 #define KEY_W 119
+#define KEY_L 108
+#define KEY_H 104
+#define KEY_I 105
+#define KEY_K 107
 #define KEY_ESC 65307
 #define KEY_LEFT 65361
 #define KEY_UP 65362
 #define KEY_RIGHT 65363
 #define KEY_DOWN 65364
 #define MOVE_INTERVAL 0.3
+#define	ROTATE_ANGLE 0.1
 
+#define MAX_PITCH_RAD (M_PI / 2.0 - 0.01) // 89.4 max
+#define MIN_PITCH_RAD (-M_PI / 2.0 + 0.01)
 /**
  * @brief Swaps miniRT between full render and fast render modes.
  */
@@ -42,6 +51,56 @@ void	swap_render_mode(t_core *core)
 		mlx_loop_hook(core->mlx, render, core);
 }
 
+t_vec3 rotate_vector(t_vec3 v, t_vec3 axis, float angle)
+{
+    t_vec3 u;
+	
+	u = axis;
+    vec_normalize(&u);
+    return (
+		vec_add(vec_add(vec_scalar(v, cos(angle)),
+		vec_scalar(cross_product(&u, &v), sin(angle))),
+		vec_scalar(u, dot_product(&u, &v) * (1 - cos(angle))))
+	);
+}
+
+
+void	camera_build_basis(t_camera *cam)
+{
+	t_vec3 world_up;
+	
+	world_up = make_point3(0, 1, 0);
+	cam->forward = cam->direction;
+	vec_normalize(&cam->forward);
+	cam->right = cross_product(&world_up, &cam->forward);
+	vec_normalize(&cam->right);
+	cam->up = cross_product(&cam->forward, &cam->right);
+	vec_normalize(&cam->up);
+}
+
+void rotate_camera_pitch(t_camera *cam, float angle)
+{
+    float new_pitch;
+	
+	new_pitch = cam->pitch + angle;
+    // Clamp avoiding clipping
+    if (new_pitch > MAX_PITCH_RAD)
+        angle = MAX_PITCH_RAD - cam->pitch;
+    else if (new_pitch < MIN_PITCH_RAD)
+        angle = MIN_PITCH_RAD - cam->pitch;
+
+    cam->direction = rotate_vector(cam->direction, cam->right, angle);
+    cam->pitch += angle;
+
+    camera_build_basis(cam);
+}
+
+void rotate_camera_yaw(t_camera *cam, float angle)
+{
+    cam->direction = rotate_vector(cam->direction, cam->up, angle);
+    camera_build_basis(cam);
+}
+
 /**
  * @brief MLX trigger for key presses, closing the window when `ESC`
  * or movement keys are pressed.
@@ -57,17 +116,25 @@ static int	key_press(int key, void *param)
 	if (key == KEY_R && core->render.is_rendering == 0)
 		swap_render_mode(core);
 	if ((key == KEY_LEFT || key == KEY_A) && core->render_mode == 0)
-		core->scene.camera.position.x -= MOVE_INTERVAL;
+		core->scene.camera.position = vec_add(core->scene.camera.position, vec_scalar(core->scene.camera.right, -MOVE_INTERVAL));
 	if ((key == KEY_RIGHT || key == KEY_D) && core->render_mode == 0)
-		core->scene.camera.position.x += MOVE_INTERVAL;
+		core->scene.camera.position = vec_add(core->scene.camera.position, vec_scalar(core->scene.camera.right, MOVE_INTERVAL));
 	if ((key == KEY_UP || key == KEY_E) && core->render_mode == 0)
 		core->scene.camera.position.y += MOVE_INTERVAL;
 	if ((key == KEY_DOWN || key == KEY_Q) && core->render_mode == 0)
 		core->scene.camera.position.y -= MOVE_INTERVAL;
 	if (key == KEY_W && core->render_mode == 0)
-		core->scene.camera.position.z += MOVE_INTERVAL;
+		core->scene.camera.position = vec_add(vec_scalar(core->scene.camera.forward, MOVE_INTERVAL), core->scene.camera.position);
 	if (key == KEY_S && core->render_mode == 0)
-		core->scene.camera.position.z -= MOVE_INTERVAL;
+		core->scene.camera.position = vec_add(core->scene.camera.position, vec_scalar(core->scene.camera.forward, -MOVE_INTERVAL));
+	if (key == KEY_H && core->render_mode == 0)
+		rotate_camera_yaw(&core->scene.camera, -ROTATE_ANGLE);
+	if (key == KEY_L && core->render_mode == 0)
+		rotate_camera_yaw(&core->scene.camera, ROTATE_ANGLE);
+	if (key == KEY_I && core->render_mode == 0)
+		rotate_camera_pitch(&core->scene.camera, -ROTATE_ANGLE);
+	if (key == KEY_K && core->render_mode == 0)
+		rotate_camera_pitch(&core->scene.camera, ROTATE_ANGLE);
 	return (0);
 }
 

--- a/src/mlx.c
+++ b/src/mlx.c
@@ -16,7 +16,7 @@
 #define KEY_S 115
 #define KEY_W 119
 #define KEY_L 108
-#define KEY_H 104
+#define KEY_J 106
 #define KEY_I 105
 #define KEY_K 107
 #define KEY_ESC 65307
@@ -24,8 +24,8 @@
 #define KEY_UP 65362
 #define KEY_RIGHT 65363
 #define KEY_DOWN 65364
-#define MOVE_INTERVAL 0.08
-#define	ROTATE_ANGLE 0.016
+#define MOVE_INTERVAL 0.35
+#define	ROTATE_ANGLE 0.03
 
 #define MAX_PITCH_RAD (M_PI / 2.0 - 0.01) // 89.4 max
 #define MIN_PITCH_RAD (-M_PI / 2.0 + 0.01)
@@ -160,7 +160,7 @@ void	update_camera(t_core *core)
 	if (core->key_state[KEY_S] && core->render_mode == 0)
 		core->scene.camera.position = vec_add(core->scene.camera.position,
 		vec_scalar(core->scene.camera.forward, -MOVE_INTERVAL));
-	if (core->key_state[KEY_H] && core->render_mode == 0)
+	if (core->key_state[KEY_J] && core->render_mode == 0)
 		rotate_camera_yaw(&core->scene.camera, -ROTATE_ANGLE);
 	if (core->key_state[KEY_L] && core->render_mode == 0)
 		rotate_camera_yaw(&core->scene.camera, ROTATE_ANGLE);

--- a/src/movement/camera_movement.c
+++ b/src/movement/camera_movement.c
@@ -1,0 +1,62 @@
+#include "material.h"
+#include "minirt.h"
+#include "mlx.h"
+#include "vector.h"
+#include "movement.h"
+
+#include <X11/X.h>
+#include <stdint.h>
+#include <stdio.h>
+
+/**
+ * @brief Applies position changes when the proper key is held.
+ */
+static void	update_camera_pos(t_core *core)
+{
+	if (core->key_state[KEY_A] && core->render_mode == 0)
+		core->scene.camera.position = vec_add(core->scene.camera.position,
+				vec_scalar(core->scene.camera.right, -MOVE_INTERVAL));
+	if (core->key_state[KEY_D] && core->render_mode == 0)
+		core->scene.camera.position = vec_add(core->scene.camera.position,
+				vec_scalar(core->scene.camera.right, MOVE_INTERVAL));
+	if (core->key_state[KEY_E] && core->render_mode == 0)
+		core->scene.camera.position.y += MOVE_INTERVAL;
+	if (core->key_state[KEY_Q] && core->render_mode == 0)
+		core->scene.camera.position.y -= MOVE_INTERVAL;
+	if (core->key_state[KEY_W] && core->render_mode == 0)
+		core->scene.camera.position = vec_add(vec_scalar(
+					core->scene.camera.forward, MOVE_INTERVAL),
+				core->scene.camera.position);
+	if (core->key_state[KEY_S] && core->render_mode == 0)
+		core->scene.camera.position = vec_add(core->scene.camera.position,
+				vec_scalar(core->scene.camera.forward, -MOVE_INTERVAL));
+}
+
+/**
+ * @brief Applies Yaw or Pitch rotations when the proper key is held.
+ */
+static void	update_camera_rot(t_core *core)
+{
+	if (core->key_state[KEY_J] && core->render_mode == 0)
+		rotate_camera_yaw(&core->scene.camera, -ROTATE_ANGLE);
+	if (core->key_state[KEY_L] && core->render_mode == 0)
+		rotate_camera_yaw(&core->scene.camera, ROTATE_ANGLE);
+	if (core->key_state[KEY_I] && core->render_mode == 0)
+		rotate_camera_pitch(&core->scene.camera, -ROTATE_ANGLE);
+	if (core->key_state[KEY_K] && core->render_mode == 0)
+		rotate_camera_pitch(&core->scene.camera, ROTATE_ANGLE);
+}
+
+/**
+ * @brief Checks if camera movements needs to be made each fast_render loop
+
+	update_camera() is called in the fast render loop,
+	applying the movements depending on the key_state value of each key.
+
+	key_state[KEY_J] = 1 would mean the J key is currently held.
+ */
+void	update_camera(t_core *core)
+{
+	update_camera_pos(core);
+	update_camera_rot(core);
+}

--- a/src/movement/camera_rotation.c
+++ b/src/movement/camera_rotation.c
@@ -1,0 +1,81 @@
+#include "material.h"
+#include "minirt.h"
+#include "mlx.h"
+#include "vector.h"
+#include "movement.h"
+
+#include <X11/X.h>
+#include <stdint.h>
+#include <stdio.h>
+
+/**
+ * @brief Rodrigues' rotation formula
+
+	Give it the direction, the axis you want to rotate (Right/Up)
+	and the angle you want to apply on the axis, and boom, works.
+	
+	rotate_vector(cam->direction, cam->up, -0.3) < Cam goes down.
+ */
+t_vec3	rotate_vector(t_vec3 v, t_vec3 axis, float angle)
+{
+	t_vec3	u;
+
+	u = axis;
+	vec_normalize(&u);
+	return (
+		vec_add(
+			vec_add(
+				vec_scalar(v, cos(angle)),
+				vec_scalar(cross_product(&u, &v), sin(angle))
+			),
+			vec_scalar(u, dot_product(&u, &v) * (1 - cos(angle))))
+	);
+}
+
+/**
+ * @brief Remake a camera with the correct vectors
+
+	This is needed as when we apply a rotation of any kind,
+	the other vectors are not aligned anymore.
+
+	If we look a bit on the left or right with the camera,
+	we need to reassign where the Forward and Up vectors are.
+ */
+void	camera_build_basis(t_camera *cam)
+{
+	cam->forward = cam->direction;
+	vec_normalize(&cam->forward);
+	cam->right = cross_product(&(t_point3){0, 1, 0}, &cam->forward);
+	vec_normalize(&cam->right);
+	cam->up = cross_product(&cam->forward, &cam->right);
+	vec_normalize(&cam->up);
+}
+
+/**
+ * @brief Builds a new camera with a new Up/down angle applied.
+
+	The Pitch is also capped so we don't go too far and end up
+	looking "behind" by going completely Up or Down.
+ */
+void	rotate_camera_pitch(t_camera *cam, float angle)
+{
+	float	new_pitch;
+
+	new_pitch = cam->pitch + angle;
+	// Clamp avoiding clipping
+	if (new_pitch > MAX_PITCH_RAD)
+		angle = MAX_PITCH_RAD - cam->pitch;
+	else if (new_pitch < MIN_PITCH_RAD)
+		angle = MIN_PITCH_RAD - cam->pitch;
+	cam->direction = rotate_vector(cam->direction, cam->right, angle);
+	cam->pitch += angle;
+	camera_build_basis(cam);
+}
+/**
+ * @brief Builds a new camera with a new Left/Right angle applied.
+ */
+void	rotate_camera_yaw(t_camera *cam, float angle)
+{
+	cam->direction = rotate_vector(cam->direction, cam->up, angle);
+	camera_build_basis(cam);
+}

--- a/src/render.c
+++ b/src/render.c
@@ -121,7 +121,9 @@ static void	process_bloc_render(void)
 
 	color = ray_color(
 			get_scene()->camera.position,
+			camera_apply_rotation(
 			camera_to_viewport(get_core()->render.x, get_core()->render.y),
+			&get_scene()->camera),
 			new_range(1, INFINITY), MAXDEPTH
 		);
 	img_put_pixel(&get_core()->img,

--- a/src/scene/camera.c
+++ b/src/scene/camera.c
@@ -2,19 +2,39 @@
 #include "camera.h"
 #include "point3.h"
 #include "minirt.h"
+#include "vector.h"
 
 #include <assert.h>
 #include <stdio.h>
 
+t_vec3 camera_apply_rotation(t_vec3 v, t_camera *cam)
+{
+	return (
+		(t_vec3){
+		v.x * cam->right.x + v.y * cam->up.x + v.z * cam->forward.x,
+		v.x * cam->right.y + v.y * cam->up.y + v.z * cam->forward.y,
+		v.x * cam->right.z + v.y * cam->up.z + v.z * cam->forward.z
+	}
+	);
+}
+
 void	create_camera(t_point3 position, t_vec3 direction, float fov)
 {
 	t_camera	*camera;
+	t_vec3		world_up;
 
-	assert("Field of view" && fov > 0 && fov < 180);
+	world_up = make_point3(0, 1, 0);
 	camera = &get_scene()->camera;
 	camera->position = position;
 	camera->direction = direction;
 	camera->fov = fov;
+	camera->forward = direction;
+	vec_normalize(&camera->forward);
+	camera->right = cross_product(&world_up, &camera->forward);
+	vec_normalize(&camera->right);
+	camera->up = cross_product(&camera->right, &camera->forward);
+	vec_normalize(&camera->up);
+	camera->up = point3_scale(&camera->up, -1);
 }
 
 void	print_camera(t_camera *camera)

--- a/src/utils/vector.c
+++ b/src/utils/vector.c
@@ -60,3 +60,13 @@ double	vec_cos(t_vec3 *v1, t_vec3 *v2)
 	assert("Vector 2" && v2);
 	return (dot_product(v1, v2) / (vec_len(v1) * vec_len(v2)));
 }
+
+t_vec3 vec_add(t_vec3 v1, t_vec3 v2)
+{
+    return (t_vec3){ v1.x + v2.x, v1.y + v2.y, v1.z + v2.z };
+}
+
+t_vec3 vec_scalar(t_vec3 v, float scalar)
+{
+    return (t_vec3){ v.x * scalar, v.y * scalar, v.z * scalar };
+}


### PR DESCRIPTION
# Camera Rotation

I first tried using a rotation matrix forumla but that didn't work well. I ended up using [Rodrigues' rotation formula](https://en.wikipedia.org/wiki/Rodrigues%27_rotation_formula), which code/function-wise, made more sense to me. You can read the comments in `src/movement/camera_rotation.c` to check out how it works, I hope it's not too hard to understand.

Basically the formula applies an angle on a vector with a given axis, something like `rotate_vector(cam->direction, cam->up, 0.3)`. After applying an angle, you need to rebuild the camera as the 2 other vectors (right and up) will be misplaced compared to the one you just moved. Feel free to ask if anything is confusing :3

Another thing I added is a capped max pitch. Without it, when reaching an angle too close or higher/lower than 90° an issue would occur where the camera would rebuild itself turned around. Looking all the way down and going under -90° would have the camera rebuild the vectors the other way around. Just like if you were turning around 180°.

# Smoother movement

Cool MLX thing that should be a premade feature.

Instead of relying on every loop to hold an input, we create two hooks with the flags/mask `key_press` and `key_release`.

the `core` now has an `int key_state[256]` array, meant for storing a held/non-held state for 256 possible keys. 1 means held, 0 is not held. Linux's MLX has simpler keycodes than MacOS and most of them fit in the 0-255 range (damn you ESC and arrow keys). Finally, the `update_camera()` function gets called in every fast render loop, which checks for every held key and applies all the pos/rot changes. This makes the movements smoother and allows for holding multiple keys at once.

_(I added `vector_add` and `vector_scalar` a while ago, feel free to change something in there if it's outdated)_

**♥ :3**