### PR TITLE
Fix error messages as per the subject

### DIFF
--- a/src/minirt.c
+++ b/src/minirt.c
@@ -86,7 +86,7 @@ int	main(int argc, char **argv)
 		return (perror("miniRT - parse_scene (open)"), print_ps(OPEN_ERR, 0));
 	parse_status = parse_scene(scene_fd);
 	if (parse_status != 0)
-		return (printf("[!] - Error during parsing!\n"), rt_kill(parse_status));
+		return (rt_kill(parse_status));
 	print_scene(&core->scene);
 	init_window();
 	printf("================\n");

--- a/src/parsing/parsing.c
+++ b/src/parsing/parsing.c
@@ -106,9 +106,9 @@ static t_ps	check_line(char *line)
  */
 t_ps	print_ps(t_ps status, int line_n)
 {
-	if (status == DONE)
-		printf("[!] - Done parsing scene!\n");
-	else if (status == FILE_ERR)
+	if (status != DONE)
+		printf("Error\n");
+	if (status == FILE_ERR)
 		printf("[!] - Path doesn't end in .rt!\n");
 	else if (status == OPEN_ERR)
 		printf("[!] - Failed to open scene file!\n");


### PR DESCRIPTION
As per the subject, make error messages during parsing start with `Error\n` and only then followed by the actual error.